### PR TITLE
Use Base64.encode/decode after/befor encrypting

### DIFF
--- a/lib/crypt_keeper/provider/mysql_aes.rb
+++ b/lib/crypt_keeper/provider/mysql_aes.rb
@@ -18,14 +18,16 @@ module CryptKeeper
       #
       # Returns an encrypted string
       def encrypt(value)
-        escape_and_execute_sql(["SELECT AES_ENCRYPT(?, ?)", value, key]).first
+        Base64.encode64 escape_and_execute_sql(
+          ["SELECT AES_ENCRYPT(?, ?)", value, key]).first
       end
 
       # Public: Decrypts a string
       #
       # Returns a plaintext string
       def decrypt(value)
-        escape_and_execute_sql(["SELECT AES_DECRYPT(?, ?)", value, key]).first
+        escape_and_execute_sql(
+          ["SELECT AES_DECRYPT(?, ?)", Base64.decode64(value), key]).first
       end
 
       private

--- a/spec/provider/mysql_aes_spec.rb
+++ b/spec/provider/mysql_aes_spec.rb
@@ -11,7 +11,7 @@ module CryptKeeper
       # into a spec :). This is a Base64 encoded string of 'test' AES encrypted
       # by AES_ENCRYPT()
       let(:cipher_text) do
-        Base64.decode64 "nbKOoWn8kvAw9k/C2Mex6Q==\n"
+        "nbKOoWn8kvAw9k/C2Mex6Q==\n"
       end
 
       subject { MysqlAes.new key: 'candy' }


### PR DESCRIPTION
Some versions of ruby do not deal with with the binary that MySQL's
AES_ENCRYPT() returns. This fixes that issue by encoding encrypted strings
before storing them in the DB. It also takes care of decoding as well.
