### PR TITLE
PostgreSQL expects strings when using pgp_sym_encrypt/decrypt functions.

### DIFF
--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -19,7 +19,7 @@ module CryptKeeper
       #
       # Returns an encrypted string
       def encrypt(value)
-        escape_and_execute_sql(["SELECT pgp_sym_encrypt(?, ?)", value, key])['pgp_sym_encrypt']
+        escape_and_execute_sql(["SELECT pgp_sym_encrypt(?, ?)", value.to_s, key])['pgp_sym_encrypt']
       end
 
       # Public: Decrypts a string

--- a/spec/provider/postgres_pgp_spec.rb
+++ b/spec/provider/postgres_pgp_spec.rb
@@ -6,7 +6,10 @@ module CryptKeeper
       use_postgres
 
       let(:cipher_text) { '\\xc30d0407030283b15f71b6a7d0296cd23501bd2c8fe3c7a56005ff4619527c4291509a78c77a6758cddd2a14acbde589fa10b3e0686865182d3beadaf237b9f928e7ba1810b8' }
-      let(:plain_text) { 'test' }
+      let(:plain_text)  { 'test' }
+
+      let(:integer_cipher_text) { '\xc30d040703028c65c58c0e9d015360d2320125112fc38f094e57cce1c0313f3eea4a7fc3e95c048bc319e25003ab6f29ceabe3609089d12094508c1eb79a2d70f95233' }
+      let(:integer_plain_text) { 1 }
 
       subject { PostgresPgp.new key: 'candy' }
 
@@ -22,6 +25,11 @@ module CryptKeeper
         it "should encrypt the string" do
           subject.encrypt(plain_text).should_not == plain_text
           subject.encrypt(plain_text).should_not be_empty
+        end
+
+        it "encrypts integers" do
+          subject.encrypt(integer_plain_text).should_not == integer_plain_text
+          subject.encrypt(integer_plain_text).should_not be_empty
         end
       end
 


### PR DESCRIPTION
Passing an integer to an encrypted attribute causes this error to be raised:

  ActiveRecord::StatementInvalid: PG::Error: ERROR:  function
 pgp_sym_encrypt(integer, unknown) does not exist
 LINE 1: SELECT pgp_sym_encrypt(1, '...

Since encrypt= is the only method that deals with user provided data, I am
only patching it in the encrypt= method. decrypt= reads values from the db
which are strings at that point.
