### PR TITLE
Fix for OpenSSL::Cipher::CipherError: iv length too short

### DIFF
--- a/lib/crypt_keeper/provider/aes.rb
+++ b/lib/crypt_keeper/provider/aes.rb
@@ -33,9 +33,7 @@ module CryptKeeper
       def encrypt(value)
         aes.encrypt
         aes.key = key
-        iv      = rand.to_s
-        aes.iv  = iv
-        Base64::encode64("#{iv}#{SEPARATOR}#{aes.update(value.to_s) + aes.final}")
+        Base64::encode64("#{aes.random_iv}#{SEPARATOR}#{aes.update(value.to_s) + aes.final}")
       end
 
       # Public: Decrypt a string


### PR DESCRIPTION
I am periodically seeing the exception:

OpenSSL::Cipher::CipherError: iv length too short

This request changes the AES encryption provider to use the OpenSSL random_iv instead of rand.to_s.
