### PR TITLE
Handle nil and empty string cleanly

### DIFF
--- a/lib/crypt_keeper/provider/aes.rb
+++ b/lib/crypt_keeper/provider/aes.rb
@@ -29,8 +29,11 @@ module CryptKeeper
 
       # Public: Encrypt a string
       #
-      # Returns a string
+      # Note: nil and empty strings are not encryptable with AES.
+      # When they are encountered, the orignal value is returned.
+      # Otherwise, returns the encrypted string
       def encrypt(value)
+        return value if value == '' || value.nil?
         aes.encrypt
         aes.key = key
         Base64::encode64("#{aes.random_iv}#{SEPARATOR}#{aes.update(value.to_s) + aes.final}")
@@ -38,8 +41,11 @@ module CryptKeeper
 
       # Public: Decrypt a string
       #
-      # Returns a string
+      # Note: nil and empty strings are not encryptable with AES (and thus cannot be decrypted).
+      # When they are encountered, the orignal value is returned.
+      # Otherwise, returns the decrypted string
       def decrypt(value)
+        return value if value == '' || value.nil?
         iv, value = Base64::decode64(value.to_s).split(SEPARATOR)
         aes.decrypt
         aes.key = key

--- a/spec/provider/aes_spec.rb
+++ b/spec/provider/aes_spec.rb
@@ -21,6 +21,22 @@ module CryptKeeper
 
         specify { encrypted.should_not == 'string' }
         specify { encrypted.should_not be_blank }
+
+        context "an empty string" do
+          let(:encrypted) do
+            subject.encrypt ''
+          end
+
+          specify { encrypted.should == '' }
+        end
+
+        context "a nil" do
+          let(:encrypted) do
+            subject.encrypt nil
+          end
+
+          specify { encrypted.should be_nil }
+        end
       end
 
       describe "#decrypt" do
@@ -29,6 +45,22 @@ module CryptKeeper
         end
 
         specify { decrypted.should == 'string' }
+
+        context "an empty string" do
+          let(:decrypted) do
+            subject.decrypt ''
+          end
+
+          specify { decrypted.should == '' }
+        end
+
+        context "a nil" do
+          let(:decrypted) do
+            subject.decrypt nil
+          end
+
+          specify { decrypted.should be_nil }
+        end
       end
     end
   end


### PR DESCRIPTION
Updates AES encryptor `#encrypt` and `#decrypt` to return value as-is when value is nil or the empty string.
