### PR TITLE
Handle activemodel::missingattributeerror on select in activerecord4

### DIFF
--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -68,6 +68,12 @@ module CryptKeeper
         record = SensitiveData.create!(storage: 'testing')
         SensitiveData.find(record).storage.should == 'testing'
       end
+
+      describe "Selecting specific column" do
+        it "should not raise error if encrypted_column is not included" do
+          expect{ SensitiveData.select(:name).to_a}.to_not raise_error(ActiveModel::MissingAttributeError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
From the activerecord 4 documentation:

> Accessing attributes of an object that do not have fields retrieved by a select will throw 
> ActiveModel::MissingAttributeError:
> 
> Model.select(:field).first.other_field
> ActiveModel::MissingAttributeError: missing attribute: other_field

Which breaks compatibility of this gem with rails 4. This pull request fixes the issue.
