### PR TITLE
Adding an enhanced AES

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ simple that *just works*.
 
 ```ruby
 class MyModel < ActiveRecord::Base
-  crypt_keeper :field, :other_field, :encryptor => :aes, :key => 'super_good_password'
+  crypt_keeper :field, :other_field, :encryptor => :aes, :key => 'super_good_password', salt: 'salt'
 end
 
 model = MyModel.new(field: 'sometext')
@@ -53,12 +53,15 @@ There are three included encryptors.
 
 * [AES](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/provider/aes.rb)
   * Encryption is peformed using AES-256 via OpenSSL.
+  * Passphrases are derived using [PBKDF2](http://en.wikipedia.org/wiki/PBKDF2)
 
 
 * [MySQL AES](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/provider/mysql_aes.rb)
   * Encryption is peformed MySQL's native AES functions.
   * ActiveRecord logs are [automatically](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/log_subscriber/mysql_aes.rb)
     filtered for you to protect sensitive data from being logged.
+  * Passphrases are derived using [PBKDF2](http://en.wikipedia.org/wiki/PBKDF2)
+
 
 
 * [PostgreSQL PGP](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/provider/postgres_pgp.rb).
@@ -68,6 +71,7 @@ There are three included encryptors.
   * ActiveRecord logs are [automatically](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/log_subscriber/postgres_pgp.rb)
     filtered for you to protect senitive data from being logged.
   * Custom options can be set through the `:pgcrypto_options`. E.g. `crypt_keeper :field, encryptor: :postgres_pgp, pgcrypto_options: 'compress-level=9'
+  * Passphrases are hashed by PostgresSQL itself using a [String2Key (S2K)](http://www.postgresql.org/docs/9.2/static/pgcrypto.html) algorithm. This is rather similar to crypt() algorithms — purposefully slow and with random salt — but it produces a full-length binary key.
 
 ## Searching
 Searching ciphertext is a complex problem that varies depending on the encryption algorithm you choose. All of the bundled providers include search support, but they have some caveats. 

--- a/crypt_keeper.gemspec
+++ b/crypt_keeper.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'activerecord',  '>= 3.1', '< 4.1'
   gem.add_runtime_dependency 'activesupport', '>= 3.1', '< 4.1'
+  gem.add_runtime_dependency 'aes',           '~> 0.5.0'
+  gem.add_runtime_dependency 'armor',         '~> 0.0.2'
 
   gem.add_development_dependency 'rspec',       '~> 2.13.0'
   gem.add_development_dependency 'guard',       '~> 1.8.0'

--- a/gemfiles/activerecord_3_1.gemfile.lock
+++ b/gemfiles/activerecord_3_1.gemfile.lock
@@ -1,9 +1,11 @@
 PATH
   remote: /Users/justin/work/jmazzi/crypt_keeper
   specs:
-    crypt_keeper (0.14.0.pre)
+    crypt_keeper (0.15.0.pre)
       activerecord (>= 3.1, < 4.1)
       activesupport (>= 3.1, < 4.1)
+      aes (~> 0.5.0)
+      armor (~> 0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -19,10 +21,12 @@ GEM
       tzinfo (~> 0.3.29)
     activesupport (3.1.12)
       multi_json (~> 1.0)
+    aes (0.5.0)
     appraisal (0.5.2)
       bundler
       rake
     arel (2.2.3)
+    armor (0.0.2)
     builder (3.0.4)
     coderay (1.0.9)
     coveralls (0.7.0)
@@ -51,7 +55,7 @@ GEM
     lumberjack (1.0.4)
     method_source (0.8.2)
     mime-types (1.25)
-    multi_json (1.8.0)
+    multi_json (1.8.2)
     mysql2 (0.3.13)
     pg (0.15.1)
     pry (0.9.12.2)
@@ -83,8 +87,8 @@ GEM
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     thor (0.18.1)
-    tins (0.11.0)
-    tzinfo (0.3.37)
+    tins (0.12.0)
+    tzinfo (0.3.38)
 
 PLATFORMS
   ruby

--- a/gemfiles/activerecord_3_2.gemfile.lock
+++ b/gemfiles/activerecord_3_2.gemfile.lock
@@ -1,9 +1,11 @@
 PATH
   remote: /Users/justin/work/jmazzi/crypt_keeper
   specs:
-    crypt_keeper (0.14.0.pre)
+    crypt_keeper (0.15.0.pre)
       activerecord (>= 3.1, < 4.1)
       activesupport (>= 3.1, < 4.1)
+      aes (~> 0.5.0)
+      armor (~> 0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -19,10 +21,12 @@ GEM
     activesupport (3.2.14)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
+    aes (0.5.0)
     appraisal (0.5.2)
       bundler
       rake
     arel (3.0.2)
+    armor (0.0.2)
     builder (3.0.4)
     coderay (1.0.9)
     coveralls (0.7.0)
@@ -51,7 +55,7 @@ GEM
     lumberjack (1.0.4)
     method_source (0.8.2)
     mime-types (1.25)
-    multi_json (1.8.0)
+    multi_json (1.8.2)
     mysql2 (0.3.13)
     pg (0.15.1)
     pry (0.9.12.2)
@@ -83,8 +87,8 @@ GEM
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     thor (0.18.1)
-    tins (0.11.0)
-    tzinfo (0.3.37)
+    tins (0.12.0)
+    tzinfo (0.3.38)
 
 PLATFORMS
   ruby

--- a/gemfiles/activerecord_4_0.gemfile.lock
+++ b/gemfiles/activerecord_4_0.gemfile.lock
@@ -1,9 +1,11 @@
 PATH
   remote: /Users/justin/work/jmazzi/crypt_keeper
   specs:
-    crypt_keeper (0.14.0.pre)
+    crypt_keeper (0.15.0.pre)
       activerecord (>= 3.1, < 4.1)
       activesupport (>= 3.1, < 4.1)
+      aes (~> 0.5.0)
+      armor (~> 0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -23,10 +25,12 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
+    aes (0.5.0)
     appraisal (0.5.2)
       bundler
       rake
     arel (4.0.0)
+    armor (0.0.2)
     atomic (1.1.14)
     builder (3.1.4)
     coderay (1.0.9)
@@ -57,7 +61,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25)
     minitest (4.7.5)
-    multi_json (1.8.0)
+    multi_json (1.8.2)
     mysql2 (0.3.13)
     pg (0.15.1)
     pry (0.9.12.2)
@@ -91,8 +95,8 @@ GEM
     thor (0.18.1)
     thread_safe (0.1.3)
       atomic
-    tins (0.11.0)
-    tzinfo (0.3.37)
+    tins (0.12.0)
+    tzinfo (0.3.38)
 
 PLATFORMS
   ruby

--- a/lib/crypt_keeper/helper.rb
+++ b/lib/crypt_keeper/helper.rb
@@ -10,6 +10,14 @@ module CryptKeeper
       end
     end
 
+    module DigestPassphrase
+      def digest_passphrase(key, salt)
+        raise ArgumentError.new("Missing :key") if key.blank?
+        raise ArgumentError.new("Missing :salt") if salt.blank?
+        ::Armor.digest(key, salt)
+      end
+    end
+
     module Serializer
       def dump(value)
         if value.blank?

--- a/lib/crypt_keeper/log_subscriber/mysql_aes.rb
+++ b/lib/crypt_keeper/log_subscriber/mysql_aes.rb
@@ -12,7 +12,7 @@ module CryptKeeper
 
       # Public: Prevents sensitive data from being logged
       def sql_with_mysql_aes(event)
-        filter = /(aes_(encrypt|decrypt))\(((.|\n)*?)\)/i
+        filter = /(aes_(encrypt|decrypt))\(.*\)/i
 
         event.payload[:sql] = event.payload[:sql].gsub(filter) do |_|
           "#{$1}([FILTERED])"

--- a/lib/crypt_keeper/log_subscriber/postgres_pgp.rb
+++ b/lib/crypt_keeper/log_subscriber/postgres_pgp.rb
@@ -12,10 +12,10 @@ module CryptKeeper
 
       # Public: Prevents sensitive data from being logged
       def sql_with_postgres_pgp(event)
-        filter = /(pgp_sym_(encrypt|decrypt))\(((.|\n)*?)\)/i
+        filter = /(\(*)pgp_sym_(?<operation>decrypt|encrypt)(\(+.*\)+)/i
 
         event.payload[:sql] = event.payload[:sql].gsub(filter) do |_|
-          "#{$1}([FILTERED])"
+          "#{$~[:operation]}([FILTERED])"
         end
 
         sql_without_postgres_pgp(event)

--- a/lib/crypt_keeper/provider/aes.rb
+++ b/lib/crypt_keeper/provider/aes.rb
@@ -1,10 +1,10 @@
-require 'digest/sha2'
-require 'openssl'
-require 'base64'
+require 'aes'
+require 'armor'
 
 module CryptKeeper
   module Provider
     class Aes
+      include CryptKeeper::Helper::DigestPassphrase
       # A value to split the iv and cipher text with
       SEPARATOR = ":crypt_keeper:"
 
@@ -16,16 +16,9 @@ module CryptKeeper
 
       # Public: Initializes the class
       #
-      #   options - A hash of options. :key is required
+      #   options - A hash of options. :key and :salt are required
       def initialize(options = {})
-        @aes         = ::OpenSSL::Cipher::Cipher.new("AES-256-CBC")
-        @aes.padding = 1
-
-        key = options.fetch(:key) do
-          raise ArgumentError, "Missing :key"
-        end
-
-        @key = Digest::SHA256.digest(key)
+        @key = digest_passphrase(options[:key], options[:salt])
       end
 
       # Public: Encrypt a string
@@ -34,9 +27,7 @@ module CryptKeeper
       # When they are encountered, the orignal value is returned.
       # Otherwise, returns the encrypted string
       def encrypt(value)
-        aes.encrypt
-        aes.key = key
-        Base64::encode64("#{aes.random_iv}#{SEPARATOR}#{aes.update(value.to_s) + aes.final}")
+        AES.encrypt(value, key)
       end
 
       # Public: Decrypt a string
@@ -45,11 +36,7 @@ module CryptKeeper
       # When they are encountered, the orignal value is returned.
       # Otherwise, returns the decrypted string
       def decrypt(value)
-        iv, value = Base64::decode64(value.to_s).split(SEPARATOR)
-        aes.decrypt
-        aes.key = key
-        aes.iv  = iv
-        aes.update(value) + aes.final
+        AES.decrypt(value, key)
       end
 
       # Public: Search for a record

--- a/lib/crypt_keeper/provider/mysql_aes.rb
+++ b/lib/crypt_keeper/provider/mysql_aes.rb
@@ -4,18 +4,16 @@ module CryptKeeper
   module Provider
     class MysqlAes
       include CryptKeeper::Helper::SQL
+      include CryptKeeper::Helper::DigestPassphrase
 
       attr_accessor :key
 
       # Public: Initializes the encryptor
       #
-      #  options - A hash, :key is required
+      #  options - A hash, :key and :salt are required
       def initialize(options = {})
         ActiveSupport.run_load_hooks(:crypt_keeper_mysql_aes_log, self)
-
-        @key = options.fetch(:key) do
-          raise ArgumentError, "Missing :key"
-        end
+        @key = digest_passphrase(options[:key], options[:salt])
       end
 
       # Public: Encrypts a string

--- a/spec/log_subscriber/postgres_pgp_spec.rb
+++ b/spec/log_subscriber/postgres_pgp_spec.rb
@@ -16,7 +16,15 @@ module CryptKeeper::LogSubscriber
     end
 
     let(:output_query) do
-      "SELECT pgp_sym_encrypt([FILTERED]), pgp_sym_decrypt([FILTERED]) FROM DUAL;"
+      "SELECT encrypt([FILTERED]) FROM DUAL;"
+    end
+
+    let(:input_search_query) do
+      "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE ((pgp_sym_decrypt('f'), 'tool') = 'blah')) AND secret = 'testing'"
+    end
+
+    let(:output_search_query) do
+      "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE decrypt([FILTERED]) AND secret = 'testing'"
     end
 
     it "filters pgp functions" do
@@ -25,6 +33,22 @@ module CryptKeeper::LogSubscriber
       end
 
       subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
+    end
+
+    it "filters pgp functions in lowercase" do
+      subject.should_receive(:sql_without_postgres_pgp) do |event|
+        event.payload[:sql].should == output_query.downcase.gsub(/filtered/, 'FILTERED')
+      end
+
+      subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query.downcase }))
+    end
+
+    it "filters pgp functions when searching" do
+      subject.should_receive(:sql_without_postgres_pgp) do |event|
+        event.payload[:sql].should == output_search_query
+      end
+
+      subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_search_query }))
     end
   end
 end

--- a/spec/provider/aes_spec.rb
+++ b/spec/provider/aes_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 module CryptKeeper
   module Provider
     describe Aes do
-      subject { Aes.new(key: 'cake') }
+      subject { Aes.new(key: 'cake', salt: 'salt') }
 
       describe "#initialize" do
-        let(:hexed_key) do
-          Digest::SHA256.digest('cake')
+        let(:digested_key) do
+          ::Armor.digest('cake', 'salt')
         end
 
-        its(:key) { should == hexed_key }
+        its(:key) { should == digested_key }
         specify { expect { Aes.new }.to raise_error(ArgumentError, "Missing :key") }
       end
 
@@ -25,7 +25,7 @@ module CryptKeeper
 
       describe "#decrypt" do
         let(:decrypted) do
-          subject.decrypt "MC41MDk5MjI2NjgxMDI1MDI2OmNyeXB0X2tlZXBlcjpPI/8dCqWXDMVj7Jqs\nuwf/\n"
+          subject.decrypt "V02ebRU2wLk25AizasROVg==$kE+IpRaUNdBfYqR+WjMqvA=="
         end
 
         specify { decrypted.should == 'string' }

--- a/spec/provider/mysql_aes_spec.rb
+++ b/spec/provider/mysql_aes_spec.rb
@@ -11,15 +11,16 @@ module CryptKeeper
       # into a spec :). This is a Base64 encoded string of 'test' AES encrypted
       # by AES_ENCRYPT()
       let(:cipher_text) do
-        "nbKOoWn8kvAw9k/C2Mex6Q==\n"
+        "fBN8i7bx/DGAA4NJ4EWi0A=="
       end
 
-      subject { MysqlAes.new key: 'candy' }
+      subject { MysqlAes.new key: ENCRYPTION_PASSWORD, salt: 'salt' }
 
-      its(:key) { should == 'candy' }
+      its(:key) { should == "825e8c5e8ca394818b307b22b8cb7d3df2735e9c1e5838b476e7719135a4f499f2133022c1a0e8597c9ac1507b0f0c44328a40049f9704fab3598c5dec120724" }
 
       describe "#initialize" do
         specify { expect { MysqlAes.new }.to raise_error(ArgumentError, "Missing :key") }
+        specify { expect { MysqlAes.new(key: 'blah') }.to raise_error(ArgumentError, "Missing :salt") }
       end
 
       describe "#encrypt" do

--- a/spec/provider/postgres_pgp_spec.rb
+++ b/spec/provider/postgres_pgp_spec.rb
@@ -5,15 +5,16 @@ module CryptKeeper
     describe PostgresPgp do
       use_postgres
 
-      let(:cipher_text) { '\\xc30d0407030283b15f71b6a7d0296cd23501bd2c8fe3c7a56005ff4619527c4291509a78c77a6758cddd2a14acbde589fa10b3e0686865182d3beadaf237b9f928e7ba1810b8' }
+      let(:cipher_text) { '\xc30d04070302f1a092093988b26873d235017203ce086a53fce1925dc39b4e972e534f192d10b94af3dcf8589abc1f828456f5d3e20b225d56006ffd1e312e3b8a492a6010e9' }
       let(:plain_text)  { 'test' }
 
-      let(:integer_cipher_text) { '\xc30d040703028c65c58c0e9d015360d2320125112fc38f094e57cce1c0313f3eea4a7fc3e95c048bc319e25003ab6f29ceabe3609089d12094508c1eb79a2d70f95233' }
+      let(:integer_cipher_text) { '\xc30d04070302c8d266353bcf2fc07dd23201153f9d9c32fbb3c36b9b0db137bf8b6c609172210d89ded63f11dff23d1ddbf5111c0266549dde26175c4425e06bb4bd6f' }
+
       let(:integer_plain_text) { 1 }
 
-      subject { PostgresPgp.new key: 'candy' }
+      subject { PostgresPgp.new key: ENCRYPTION_PASSWORD }
 
-      its(:key) { should == 'candy' }
+      its(:key) { should == ENCRYPTION_PASSWORD }
 
       describe "#initialize" do
         specify { expect { PostgresPgp.new }.to raise_error(ArgumentError, "Missing :key") }
@@ -33,6 +34,7 @@ module CryptKeeper
 
       describe "#decrypt" do
         specify { subject.decrypt(cipher_text).should == plain_text }
+        specify { subject.decrypt(integer_cipher_text).should == integer_plain_text.to_s }
       end
 
       describe "#search" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,12 @@
+ENV['ARMOR_ITER'] ||= "10"
 require 'coveralls'
 Coveralls.wear!
 require 'crypt_keeper'
 
-SPEC_ROOT = Pathname.new File.expand_path File.dirname __FILE__
+SPEC_ROOT           = Pathname.new File.expand_path File.dirname __FILE__
+AR_LOG              = SPEC_ROOT.join('debug.log').to_s
+ENCRYPTION_PASSWORD = "supermadsecretstring"
+
 Dir[SPEC_ROOT.join('support/*.rb')].each{|f| require f }
 
 RSpec.configure do |config|
@@ -13,6 +17,16 @@ RSpec.configure do |config|
   config.after :each do
     ActiveRecord::Base.descendants.each do |model|
       model.method(:delete_all).call
+    end
+  end
+
+  config.after :suite do
+    if File.exist?(AR_LOG) && ENV['TRAVIS'].present?
+      `grep \"#{ENCRYPTION_PASSWORD}\" #{AR_LOG}`
+
+      if $?.exitstatus == 0
+        raise StandardError, "\n\nERROR: The encryption password was found in the logs\n\n"
+      end
     end
   end
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,13 +1,14 @@
 require 'active_record'
 require 'logger'
 
-::ActiveRecord::Base.logger = Logger.new SPEC_ROOT.join('debug.log').to_s
+::ActiveRecord::Base.logger = Logger.new(AR_LOG)
 ::ActiveRecord::Migration.verbose = false
 
 module CryptKeeper
   class SensitiveDataMysql < ActiveRecord::Base
     self.table_name = 'sensitive_data'
-    crypt_keeper :storage, key: 'tool', encryptor: :mysql_aes
+    crypt_keeper :storage, encryptor: :mysql_aes, key: ENCRYPTION_PASSWORD,
+      salt: 'salt'
   end
 
   class SensitiveDataPg < ActiveRecord::Base


### PR DESCRIPTION
Note: This is a breaking change which will require re-encrypting all data for anyone using the AES and MySQL AES providers.
- Passphrases are now derived using [PBKDF2](http://en.wikipedia.org/wiki/PBKDF2) hashing for enhance security. Because of this change, AES now requires a `salt` param in addition to the `key`. The `salt` it used when hashing the passphrase to ensure a unique key is used when encrypting data. The [Armor](https://rubygems.org/gems/armor) gem is used to accomplish this.
- Log subscribers are now more aggressive to ensure searches do not leak keys or plaintext during a search.
- The AES provider was replaced with the [AES](https://rubygems.org/gems/aes) gem.

Close #26 
