### PR TITLE
Add encrypt_table

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ model.field #=> 'Tromsø'
 model.field.encoding #=> #<Encoding:UTF-8>
 ```
 
+## Adding encryption to an existing table
+
+If you are working with an existing table you would like to encrypt, you must use the `MyExistingModel.encrypt_table!` class method.
+
+```ruby
+class MyExistingModel < ActiveRecord::Base
+  crypt_keeper :field, :other_field, :encryptor => :aes_new, :key => 'super_good_password', salt: 'salt'
+end
+
+MyExistingModel.encrypt_table!
+```
+
+Running `encrypt_table!` will encrypt all rows in the database using the encryption method specificed by the `crypt_keeper` line in your model.
+
 ## Supported Available Encryptors
 
 There are four supported encryptors: `aes_new`, `mysql_aes_new`, `postgresql_pgp`, `postgres_pgp_public_key`.

--- a/lib/crypt_keeper/model.rb
+++ b/lib/crypt_keeper/model.rb
@@ -80,6 +80,22 @@ module CryptKeeper
         end
       end
 
+      # Public: Encrypt a table for the first time.
+      def encrypt_table!
+        enc       = encryptor_klass.new(crypt_keeper_options)
+        tmp_table = Class.new(ActiveRecord::Base).tap { |c| c.table_name = self.table_name }
+
+        transaction do
+          tmp_table.find_each do |r|
+            crypt_keeper_fields.each do |field|
+              r.send("#{field}=", enc.encrypt(r[field])) if r[field].present?
+            end
+
+            r.save!
+          end
+        end
+      end
+
       private
 
       # Private: The encryptor class


### PR DESCRIPTION
Add the ability to encrypt a table for the first time. Since serialize attempts to `load`, i.e. `decrypt`, the column, it fails because the data is not yet encrypted. This PR creates an anonymous model which has no callbacks or serializers allowing me to find each record and encrypt the columns. 
