### PR TITLE
Use lazy decryption

### DIFF
--- a/lib/crypt_keeper/helper.rb
+++ b/lib/crypt_keeper/helper.rb
@@ -17,23 +17,5 @@ module CryptKeeper
         ::Armor.digest(key, salt)
       end
     end
-
-    module Serializer
-      def dump(value)
-        if value.blank?
-          value
-        else
-          encrypt(value.to_s)
-        end
-      end
-
-      def load(value)
-        if value.blank?
-          value
-        else
-          decrypt(value)
-        end
-      end
-    end
   end
 end

--- a/lib/crypt_keeper/model.rb
+++ b/lib/crypt_keeper/model.rb
@@ -92,7 +92,7 @@ module CryptKeeper
 
           # Public: Sets the ciphertext for field_encrypted
           define_method "#{field}=" do |value|
-            unless value == self.class.decrypt_value(send("#{field}_encrypted"))
+            unless value == send(field)
               send("#{field}_will_change!")
               self.send("#{field}_encrypted=", self.class.encrypt_value(value))
             end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -16,8 +16,8 @@ module CryptKeeper
       def define_schema!
         ::ActiveRecord::Schema.define do
           create_table :sensitive_data, :force => true do |t|
-            t.column :name, :string
-            t.column :storage, :text
+            t.column :name_encrypted, :string
+            t.column :storage_encrypted, :text
             t.column :secret, :text
           end
         end


### PR DESCRIPTION
This requires that each field be renamed in the database with the suffix `_encrypted` after the column name. For example, if your column name is `secret`, the column would need to be renamed to `secret_encrypted`. Accessors are setup for `secret` and `secret=` which handles the encrypted and decryption of the column data. The data is saved in the `secret_encrypted` column in the database.

I'm moving aware from serializers because it forces row decryption on all results, even if you don't ever call the attribute that is encrypted. For simple queries you could use `select()` to omit the encrypted fields, but the results become unpredictable once a query becomes more complex and `joins` or `includes` are brought into the mix. It's very tedious to build queries that way.
