### PR TITLE
Fixed typo in list of encryptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Running `encrypt_table!` will encrypt all rows in the database using the encrypt
 
 ## Supported Available Encryptors
 
-There are four supported encryptors: `aes_new`, `mysql_aes_new`, `postgresql_pgp`, `postgres_pgp_public_key`.
+There are four supported encryptors: `aes_new`, `mysql_aes_new`, `postgres_pgp`, `postgres_pgp_public_key`.
 
 * [AES New](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/provider/aes_new.rb)
   * Encryption is peformed using AES-256 via OpenSSL.


### PR DESCRIPTION
Line 105 in model.rb causes an error if you use `postgresql_pgp`.