### PR TITLE
Dirty attribute bug in Rails 4.2

### DIFF
--- a/crypt_keeper.gemspec
+++ b/crypt_keeper.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake',        '~> 10.3.1'
   gem.add_development_dependency 'rb-fsevent',  '~> 0.9.1'
   gem.add_development_dependency 'coveralls'
-  gem.add_development_dependency 'appraisal',   '~> 1.0.0'
+  gem.add_development_dependency 'appraisal',   '~> 2.1.0'
 
   if RUBY_PLATFORM == 'java'
     gem.add_development_dependency 'jruby-openssl', '~> 0.7.7'

--- a/crypt_keeper.gemspec
+++ b/crypt_keeper.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rb-fsevent',  '~> 0.9.1'
   gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'appraisal',   '~> 2.1.0'
+  gem.add_development_dependency 'byebug'
 
   if RUBY_PLATFORM == 'java'
     gem.add_development_dependency 'jruby-openssl', '~> 0.7.7'

--- a/gemfiles/activerecord_3_1.gemfile.lock
+++ b/gemfiles/activerecord_3_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.19.0)
+    crypt_keeper (0.20.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)
@@ -22,7 +22,7 @@ GEM
     activesupport (3.1.12)
       multi_json (~> 1.0)
     aes (0.5.0)
-    appraisal (1.0.0)
+    appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -105,7 +105,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 3.1.10)
   activesupport (~> 3.1.10)
-  appraisal (~> 1.0.0)
+  appraisal (~> 2.1.0)
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)
@@ -116,3 +116,6 @@ DEPENDENCIES
   rb-fsevent (~> 0.9.1)
   rspec (~> 2.14.0)
   sqlite3
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_3_1.gemfile.lock
+++ b/gemfiles/activerecord_3_1.gemfile.lock
@@ -29,6 +29,7 @@ GEM
     arel (2.2.3)
     armor (0.0.3)
     builder (3.0.4)
+    byebug (8.2.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     celluloid-io (0.15.0)
@@ -106,6 +107,7 @@ DEPENDENCIES
   activerecord (~> 3.1.10)
   activesupport (~> 3.1.10)
   appraisal (~> 2.1.0)
+  byebug
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)

--- a/gemfiles/activerecord_3_2.gemfile.lock
+++ b/gemfiles/activerecord_3_2.gemfile.lock
@@ -29,6 +29,7 @@ GEM
     arel (3.0.3)
     armor (0.0.3)
     builder (3.0.4)
+    byebug (8.2.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     celluloid-io (0.15.0)
@@ -106,6 +107,7 @@ DEPENDENCIES
   activerecord (~> 3.2.14)
   activesupport (~> 3.2.14)
   appraisal (~> 2.1.0)
+  byebug
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)

--- a/gemfiles/activerecord_3_2.gemfile.lock
+++ b/gemfiles/activerecord_3_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.19.0)
+    crypt_keeper (0.20.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)
@@ -22,7 +22,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     aes (0.5.0)
-    appraisal (1.0.0)
+    appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -105,7 +105,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 3.2.14)
   activesupport (~> 3.2.14)
-  appraisal (~> 1.0.0)
+  appraisal (~> 2.1.0)
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)
@@ -116,3 +116,6 @@ DEPENDENCIES
   rb-fsevent (~> 0.9.1)
   rspec (~> 2.14.0)
   sqlite3
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_4_0.gemfile.lock
+++ b/gemfiles/activerecord_4_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.19.0)
+    crypt_keeper (0.20.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)
@@ -26,7 +26,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     aes (0.5.0)
-    appraisal (1.0.0)
+    appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -111,7 +111,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 4.0.0)
   activesupport (~> 4.0.0)
-  appraisal (~> 1.0.0)
+  appraisal (~> 2.1.0)
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)
@@ -122,3 +122,6 @@ DEPENDENCIES
   rb-fsevent (~> 0.9.1)
   rspec (~> 2.14.0)
   sqlite3
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_4_0.gemfile.lock
+++ b/gemfiles/activerecord_4_0.gemfile.lock
@@ -33,6 +33,7 @@ GEM
     arel (4.0.2)
     armor (0.0.3)
     builder (3.1.4)
+    byebug (8.2.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     celluloid-io (0.15.0)
@@ -112,6 +113,7 @@ DEPENDENCIES
   activerecord (~> 4.0.0)
   activesupport (~> 4.0.0)
   appraisal (~> 2.1.0)
+  byebug
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)

--- a/gemfiles/activerecord_4_1.gemfile.lock
+++ b/gemfiles/activerecord_4_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.19.0)
+    crypt_keeper (0.20.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)
@@ -24,7 +24,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     aes (0.5.0)
-    appraisal (1.0.0)
+    appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -111,7 +111,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 4.1.0)
   activesupport (~> 4.1.0)
-  appraisal (~> 1.0.0)
+  appraisal (~> 2.1.0)
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)
@@ -122,3 +122,6 @@ DEPENDENCIES
   rb-fsevent (~> 0.9.1)
   rspec (~> 2.14.0)
   sqlite3
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_4_1.gemfile.lock
+++ b/gemfiles/activerecord_4_1.gemfile.lock
@@ -31,6 +31,7 @@ GEM
     arel (5.0.1.20140414130214)
     armor (0.0.3)
     builder (3.2.2)
+    byebug (8.2.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     celluloid-io (0.15.0)
@@ -112,6 +113,7 @@ DEPENDENCIES
   activerecord (~> 4.1.0)
   activesupport (~> 4.1.0)
   appraisal (~> 2.1.0)
+  byebug
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)

--- a/gemfiles/activerecord_4_2.gemfile.lock
+++ b/gemfiles/activerecord_4_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.19.0)
+    crypt_keeper (0.20.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)
@@ -24,7 +24,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     aes (0.5.0)
-    appraisal (1.0.2)
+    appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -110,7 +110,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 4.2.0)
   activesupport (~> 4.2.0)
-  appraisal (~> 1.0.0)
+  appraisal (~> 2.1.0)
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)
@@ -121,3 +121,6 @@ DEPENDENCIES
   rb-fsevent (~> 0.9.1)
   rspec (~> 2.14.0)
   sqlite3
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_4_2.gemfile.lock
+++ b/gemfiles/activerecord_4_2.gemfile.lock
@@ -31,6 +31,7 @@ GEM
     arel (6.0.0)
     armor (0.0.3)
     builder (3.2.2)
+    byebug (8.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
@@ -111,6 +112,7 @@ DEPENDENCIES
   activerecord (~> 4.2.0)
   activesupport (~> 4.2.0)
   appraisal (~> 2.1.0)
+  byebug
   coveralls
   crypt_keeper!
   guard (~> 2.6.1)

--- a/lib/crypt_keeper/encrypted_text.rb
+++ b/lib/crypt_keeper/encrypted_text.rb
@@ -1,0 +1,15 @@
+module CryptKeeper
+  class EncryptedText < ActiveRecord::Type::String
+    def type
+      :text
+    end
+
+    def changed_in_place?(raw_old_value, new_value)
+      if new_value.is_a?(::String)
+        # Raw encrypted version could be different for the same value
+        # so we need to decrypt first
+        raw_old_value != new_value
+      end
+    end
+  end
+end

--- a/lib/crypt_keeper/model.rb
+++ b/lib/crypt_keeper/model.rb
@@ -1,5 +1,6 @@
 require 'active_support/concern'
 require 'active_support/core_ext/array/extract_options'
+require 'crypt_keeper/encrypted_text'
 
 module CryptKeeper
   module Model
@@ -68,6 +69,8 @@ module CryptKeeper
         end
 
         crypt_keeper_fields.each do |field|
+          attribute field, ::CryptKeeper::EncryptedText.new
+
           serialize field, encryptor_klass.new(crypt_keeper_options).
             extend(::CryptKeeper::Helper::Serializer)
         end

--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -1,3 +1,4 @@
+require 'byebug'
 require 'crypt_keeper/log_subscriber/postgres_pgp'
 
 module CryptKeeper
@@ -25,13 +26,15 @@ module CryptKeeper
       #
       # Returns an encrypted string
       def encrypt(value)
-        escape_and_execute_sql(["SELECT pgp_sym_encrypt(?, ?, ?)", value.to_s, key, pgcrypto_options])['pgp_sym_encrypt']
+        puts "in: #{value}"
+        escape_and_execute_sql(["SELECT pgp_sym_encrypt(?, ?, ?)", value, key, pgcrypto_options])['pgp_sym_encrypt']
       end
 
       # Public: Decrypts a string
       #
       # Returns a plaintext string
       def decrypt(value)
+        puts "out: #{value}"
         escape_and_execute_sql(["SELECT pgp_sym_decrypt(?, ?)", value, key])['pgp_sym_decrypt']
       end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module CryptKeeper
   describe Model do
-    use_sqlite
+    use_postgres
 
     subject { create_model }
 
@@ -76,6 +76,11 @@ module CryptKeeper
       it "converts numbers to strings" do
         data = subject.create!(storage: 1)
         data.reload.storage.should == "1"
+      end
+
+      it "reports encypted fields as unchanged" do
+        data = subject.create!(storage: 1)
+        data.storage_changed?.should be(false)
       end
     end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -77,11 +77,6 @@ module CryptKeeper
         data = subject.create!(storage: 1)
         data.reload.storage.should == "1"
       end
-
-      it "reports encypted fields as unchanged" do
-        data = subject.create!(storage: 1)
-        data.storage_changed?.should be(false)
-      end
     end
 
     context "Search" do

--- a/spec/provider/postgres_pgp_spec.rb
+++ b/spec/provider/postgres_pgp_spec.rb
@@ -37,6 +37,14 @@ module CryptKeeper
         specify { subject.decrypt(integer_cipher_text).should == integer_plain_text.to_s }
       end
 
+      context "changes" do
+        subject { postgres_model }
+        it "reports encypted fields as unchanged" do
+          data = subject.create!(storage: "test")
+          data.storage_changed?.should be(false)
+        end
+      end
+
       describe "#search" do
         subject { postgres_model }
 

--- a/spec/provider/postgres_pgp_spec.rb
+++ b/spec/provider/postgres_pgp_spec.rb
@@ -39,6 +39,7 @@ module CryptKeeper
 
       context "changes" do
         subject { postgres_model }
+
         it "reports encypted fields as unchanged" do
           data = subject.create!(storage: "test")
           data.storage_changed?.should be(false)


### PR DESCRIPTION
@jmazzi I think I found the specific problem.

Rails 4.2 now tracks in place changes to serialized attributes . However, the implementation [compares the raw db data to the serialized version](https://github.com/rails/rails/pull/15674/files#diff-2bd7c52253c45ccc631ca0d1199d1201R153) of the current attribute value. This is broken by encryption methods that can produce multiple valid outputs for the same input.

```
 p = postgres_model.new(storage: 45)
in: 45
out: \xc30d040703021a04b28d018384777cd2330102079850c84e05f8e2016c966fbbfaa6a6ba791bfc8cc5f3eacc99c4552e512d54f54ad73f0a1f47ff85384529facd0e5a81
in: 45
in: 45
in: 45
out: \xc30d040703025ac3b754e307f9737fd233014d77244e8f5fac0cf829b20ee0e3b2affb0d9fa64a79a0e806492c885946426d0df4e62adc3fbbc91393ac5907ffb375a5d0
#<#<Class:0x000000047d8af8> id: nil, name: nil, storage: "45", secret: nil>
(byebug) p.changes
in: 45
in: 45
out: \xc30d040703026be0b4db0491446b7cd233019331b32b9efc373f268fd81ea55df368e9c50614254ba17114c63d9b528893cd69dd301ceef709da95dca76783d6f24dbda3
```

As I suggested earlier, I think the fix for this is to define a custom AR column type, something like `EncryptedText`, that defines `#changed_in_place?` to encrypt and decrypt the new value and decrypt the old value. Otherwise I think we'll end up overriding a bunch of methods in a hacky way. 
