### PR TITLE
Replace serializers with callbacks

### DIFF
--- a/lib/crypt_keeper.rb
+++ b/lib/crypt_keeper.rb
@@ -3,6 +3,7 @@ require 'active_record'
 require 'crypt_keeper/version'
 require 'crypt_keeper/model'
 require 'crypt_keeper/helper'
+require 'crypt_keeper/callbacks'
 require 'crypt_keeper/provider/aes'
 require 'crypt_keeper/provider/aes_new'
 require 'crypt_keeper/provider/mysql_aes'
@@ -13,7 +14,7 @@ require 'crypt_keeper/provider/postgres_pgp_public_key'
 module CryptKeeper
   class << self
     attr_accessor :stub_encryption
-    alias_method :stub_encryption?, :stub_encryption 
+    alias_method :stub_encryption?, :stub_encryption
   end
 end
 

--- a/lib/crypt_keeper/callbacks.rb
+++ b/lib/crypt_keeper/callbacks.rb
@@ -1,0 +1,176 @@
+module CryptKeeper
+  # This class encapsulates ActiveRecord Callbacks run when a CryptKeeper
+  # model is saved or fetched from the database.
+  class Callbacks
+    # Public: Called when the given record's `after_save` callback fires.
+    #
+    # record - An ActiveRecord instance
+    #
+    # Returns true if the callback succeeded.
+    def self.after_save(record)
+      new(record).after_save!
+    end
+
+    # Public: Called when the given record's `after_find` callback fires.
+    #
+    # record - An ActiveRecord instance
+    #
+    # Returns true if the callback succeeded.
+    def self.after_find(record)
+      new(record).after_find!
+    end
+
+    # Public: Called when the given record's `before_save` callback fires.
+    #
+    # record - An ActiveRecord instance
+    #
+    # Returns true if the callback succeeded.
+    def self.before_save(record)
+      new(record).before_save!
+    end
+
+    # record - An ActiveRecord instance
+    def initialize(record)
+      @record    = record
+      @model     = record.class
+      @encryptor = @model.crypt_keeper_encryptor_instance
+      @fields    = @model.crypt_keeper_fields.map(&:to_s) & record.attributes.keys
+    end
+
+    # Public: Run before the model is saved.
+    #
+    # * Verify columns are the proper type
+    # * Force encoding on column values (if configured)
+    # * Encrypts fields
+    #
+    # Returns true if the callback succeeded.
+    def before_save!
+      enforce_column_types!
+      force_encoding!
+
+      @fields.each do |name|
+        if changes[name].present?
+          @record.send("#{name}=", encrypt(@record.send(name)))
+        end
+      end
+
+      true
+    end
+
+    # Public: Run after the model is saved.
+    #
+    # * Decrypts fields (they are already encrypted at this point)
+    #
+    # force - If true, force decryption on fields without checking for changes
+    #
+    # Returns true if the callback succeeded.
+    def after_save!(force: false)
+      @fields.each do |name|
+        if force || changes[name].present?
+          @record.send("#{name}=", decrypt(@record.send(name)))
+        end
+      end
+
+      true
+    end
+
+    # Public: Run after a model is loaded from the database.
+    #
+    # * Decrypts fields (they are already encrypted at this point)
+    # * Force encoding on column values (if configured)
+    # * Resets ActiveRecord::Dirty changes on CryptKeepr columns due to
+    #   encryption/decryption/encoding
+    #
+    # Returns true if the callback succeeded.
+    def after_find!
+      after_save! force: true
+      force_encoding!
+      clear_changes!
+
+      true
+    end
+
+    private
+
+    # Private: Encrypts the given value. If `CryptKeeper.stub_encryption` is
+    # enabled, or the given value is nil or a blank string, no encryption is
+    # run.
+    #
+    # value - The value to encrypt
+    #
+    # Returns a String or nil.
+    def encrypt(value)
+      if CryptKeeper.stub_encryption? || value.nil? || value == "".freeze
+        value
+      else
+        @encryptor.encrypt(value.to_s)
+      end
+    end
+
+    # Private: Decrypts the given value. If `CryptKeeper.stub_encryption` is
+    # enabled, or the given value is nil or a blank string, no decryption is
+    # run.
+    #
+    # value - The value to encrypt
+    #
+    # Returns a String or nil.
+    def decrypt(value)
+      if CryptKeeper.stub_encryption? || value.nil? || value == "".freeze
+        value
+      else
+        @encryptor.decrypt(value.to_s)
+      end
+    end
+
+    # Private: Forces encoding on encrypted fields if configured.
+    #
+    # Returns nothing.
+    def force_encoding!
+      if encoding = @model.crypt_keeper_encoding
+        @fields.each do |field|
+          @record.send(field).try(:force_encoding, encoding)
+        end
+      end
+    end
+
+    # Private: Verifies that encrypted fields exist and are of type "text".
+    #
+    # Raises ArgumentError if any fields are not configured properly.
+    #
+    # Returns nothing.
+    def enforce_column_types!
+      @model.crypt_keeper_fields.each do |field|
+        if @model.columns_hash[field.to_s].nil?
+          raise ArgumentError, "Column :#{field} does not exist"
+        elsif @model.columns_hash[field.to_s].type != :text
+          raise ArgumentError, "Column :#{field} must be of type 'text' to be used for encryption"
+        end
+      end
+    end
+
+    # Private: ActiveRecord::Dirty changes for the current record. We cache
+    # them because serialized attributes run their serializer's load/dump
+    # methods every time `#changes` is run.
+    #
+    # Returns a Hash.
+    def changes
+      @changes ||= @record.changes
+    end
+
+    # Private: Clears ActiveRecord::Dirty changes for CryptKeeper fields.
+    #
+    # Returns nothing.
+    def clear_changes!
+      if @record.respond_to?(:clear_attribute_changes, true)
+        # ActiveRecord >= 4.2
+        @record.send(:clear_attribute_changes, @fields)
+      else
+        # ActiveRecord < 4.2
+        @fields.each do |field|
+          @record.send(:previous_changes).delete(field)
+          @record.send(:changed_attributes).delete(field)
+        end
+      end
+    end
+  end
+end

--- a/lib/crypt_keeper/helper.rb
+++ b/lib/crypt_keeper/helper.rb
@@ -17,23 +17,5 @@ module CryptKeeper
         ::Armor.digest(key, salt)
       end
     end
-
-    module Serializer
-      def dump(value)
-        if value.blank? || CryptKeeper.stub_encryption?
-          value
-        else
-          encrypt(value.to_s)
-        end
-      end
-
-      def load(value)
-        if value.blank? || CryptKeeper.stub_encryption?
-          value
-        else
-          decrypt(value)
-        end
-      end
-    end
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -165,5 +165,26 @@ module CryptKeeper
         expect { subject.select(:id).first }.to_not raise_error
       end
     end
+
+    context "Dirty Attributes" do
+      subject { create_encrypted_model :storage, key: 'tool', salt: 'salt', encryptor: :aes_new, encoding: 'utf-8' }
+
+      it "doesn't leave dirty attributes after_find" do
+        subject.after_find do
+          self.name = "changed"
+        end
+
+        id = subject.create!(storage: "blah").id
+
+        changes = subject.find(id).changes
+
+        expect(changes).to have_key("name")
+        expect(changes).to_not have_key("storage")
+      end
+
+      it "doesn't leave dirty attributes after_save" do
+        expect(subject.create!(storage: "blah").changes).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
**WIP - REVIEW ONLY**
## Serializers are bad m'kay

Serialized attributes in Rails are terribly inefficient. Each time they are checked for changes (for ActiveRecord::Dirty), the serializer's load/dump methods are called multiple times -- specifically for CryptKeeper this means encrypt/decrypt, and potentially several DB queries.

On a Rails 4.2 application with CryptKeeper master and the PostgresPgp encryptor, `Model.create` calls decrypt 3 times, and encrypt 8 times per encrypted attribute# `Model#save` calls decrypt 3 times, and encrypt 6 times per encrypted attribute.

For Rails 5, `Model.create` calls decrypt 2 times, and encrypt 3 times per attribute. `Model#save` calls decrypt 2 times and encrypt 4 times per attribute.

`Model.find` behaves as expected on Rails 4.2 and 5, with only one decrypt per encrypted attribute.

Additionally, checking dirty attributes via `Model#changes` will run several decrypt calls on _every_ encrypted attribute that was loaded. Eg: with `m = Model.select(:encrypted1, :encrypted2, :non_encrypted)`, `m.changes`, `m.encrypted1_changed?` or `m.encrypted2_changed?` will decrypt all encrypted fields. Checking `m.non_encrypted_changed?` does not.
## Possible fix for serializers

One idea I toyed around with was to cache the results of CryptKeepers serializers' dump/load calls. Basically something like this:

``` ruby
module Serializer
  @dumps = @loads = {}

  def dump(value)
    @dumps.fetch(value) do
      @dumps[value] = encrypt(value)
    end
  end

  def load(value)
    @loads.fetch(value) do
      @loads[value] = decrypt(value)
    end
  end
end
```

This does seem to work well, but I don't like the idea of caching these sensitive values in memory. Additionally, we would have to figure out a way to garbage clean older entries, otherwise the caches would continue to grow for the entire life of a Rails process.

Overall though, serlizers' inefficiencies are something we've been battling since Rails 3.2, and it doesn't seem to have improved much even with Rails 5.0.
## Why callbacks?

There are three main reasons I think callbacks are a better choice for CryptKeeper.
1. The most obvious reason, is that we can reduce encrypt/decrypt calls to, at most, 2 per attribute (one encrypt, one decrypt).
2. Dirty attribute handling is better because we avoid decrypt/encrypt calls when using `Model#changes` and friends. 
3. With callbacks we have full access to the model. This means we can eventually refactor further so that there are at most 1 encrypt and 1 decrypt query that would handle _all_ attributes. With a serializer this isn't possible since they only have access to the raw value and not the model/attribute name. If this PR is merged I have another work in progress to implement this.
## Why not callbacks?

FUD? There is a lot of hate for callbacks lately. It can be difficult to troubleshoot issues with them. However, I think that their usage in CryptKeeper is relatively simple, and I think the benefits outweigh any negatives when compared to serializers.
