### PR TITLE
Add support of PostgreSQL's Raw Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ There are four supported encryptors: `aes_new`, `mysql_aes_new`, `postgres_pgp`,
     filtered for you to protect senitive data from being logged.
   * Accepts a public and private_key. The private key is optional. If the private key is not present the ciphertext value is returned instead of the plaintext. This allows you to keep the private key off certain servers. Encryption is possible with only a public key. Any server that needs access to the plaintext will need the private key.
   * Passphrases are hashed by PostgresSQL itself using a [String2Key (S2K)](http://www.postgresql.org/docs/9.2/static/pgcrypto.html) algorithm. This is rather similar to crypt() algorithms — purposefully slow and with random salt — but it produces a full-length binary key.
+  
+* [PostgresSQL Raw](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/provider/postgres_raw.rb)
+  * Encryption is performed using PostgreSQL's native [Raw Encryption Functions](https://www.postgresql.org/docs/9.1/static/pgcrypto.html#AEN142171)
+  * It requires the `pgcrypto` PostgresSQL extension:
+      `CREATE EXTENSION IF NOT EXISTS pgcrypto`
+  * ActiveRecord logs are [automatically](https://github.com/jmazzi/crypt_keeper/blob/master/lib/crypt_keeper/log_subscriber/postgres_raw.rb)
+    filtered for you to protect sensitive data from being logged.
+  * Accepts encryption with initial vector (optional) and `:pgcrypto_options` (optional). E.g. `crypt_keeper :field, encryptor: :postgres_raw, iv: 'secret', pgcrypto_options: 'bf-cbc/pad:pkcs'
+  * Comparing to PGP encryption, usage of raw encryption functions is discouraged. However, it is useful if the performance of the search or query function is concerned, and security level can be a bit compromised.   
 
 ## Deprecated Encryptors
 These encryptors are now deprecated and should be migrated from as soon as possible using the included `bin/crypt_keeper` script.
@@ -133,6 +142,9 @@ Searching ciphertext is a complex problem that varies depending on the encryptio
 * PostgresSQL PGP
  * PGP also uses a random initialization vector which means it generates unique output each time you encrypt plaintext. Although the database can be searched by performing row level decryption and comparing the plaintext, it will not be able to use an index. A scope or batch is suggested when searching.
 
+* PostgresSQL Raw
+ * PostgreSQL's Raw Encryption does not use or uses a non-random initial vector which means it is less securer but better for searching.
+ 
 ## How the search interface is used
 
 ```ruby

--- a/gemfiles/activerecord_4_1.gemfile.lock
+++ b/gemfiles/activerecord_4_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.21.0)
+    crypt_keeper (0.22.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)

--- a/gemfiles/activerecord_4_2.gemfile.lock
+++ b/gemfiles/activerecord_4_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.21.0)
+    crypt_keeper (0.22.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)

--- a/lib/crypt_keeper.rb
+++ b/lib/crypt_keeper.rb
@@ -9,6 +9,7 @@ require 'crypt_keeper/provider/mysql_aes'
 require 'crypt_keeper/provider/mysql_aes_new'
 require 'crypt_keeper/provider/postgres_pgp'
 require 'crypt_keeper/provider/postgres_pgp_public_key'
+require 'crypt_keeper/provider/postgres_raw'
 
 module CryptKeeper
   class << self

--- a/lib/crypt_keeper/log_subscriber/postgres_raw.rb
+++ b/lib/crypt_keeper/log_subscriber/postgres_raw.rb
@@ -15,7 +15,7 @@ module CryptKeeper
         filter  = /(encode\()*(\(*)(?<operation>decrypt|encrypt)(_iv)*(\(+.*\)+)/im
         payload = event.payload[:sql]
                     .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
-
+        return if CryptKeeper.silence_logs? && payload =~ filter
         event.payload[:sql] = payload.gsub(filter) do |_|
           "#{$~[:operation]}([FILTERED])"
         end

--- a/lib/crypt_keeper/log_subscriber/postgres_raw.rb
+++ b/lib/crypt_keeper/log_subscriber/postgres_raw.rb
@@ -1,0 +1,31 @@
+require 'active_support/concern'
+require 'active_support/lazy_load_hooks'
+
+module CryptKeeper
+  module LogSubscriber
+    module PostgresRaw
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method_chain :sql, :postgres_raw
+      end
+
+      # Public: Prevents sensitive data from being logged
+      def sql_with_postgres_raw(event)
+        filter  = /(encode\()*(\(*)(?<operation>decrypt|encrypt)(_iv)*(\(+.*\)+)/im
+        payload = event.payload[:sql]
+                    .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+
+        event.payload[:sql] = payload.gsub(filter) do |_|
+          "#{$~[:operation]}([FILTERED])"
+        end
+
+        sql_without_postgres_raw(event)
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load :crypt_keeper_postgres_raw_log do
+  ActiveRecord::LogSubscriber.send :include, CryptKeeper::LogSubscriber::PostgresRaw
+end

--- a/lib/crypt_keeper/provider/postgres_raw.rb
+++ b/lib/crypt_keeper/provider/postgres_raw.rb
@@ -1,0 +1,53 @@
+require 'crypt_keeper/log_subscriber/postgres_pgp'
+
+module CryptKeeper
+  module Provider
+    class PostgresRaw
+      include CryptKeeper::Helper::SQL
+
+      attr_accessor :key
+      attr_accessor :iv
+      attr_accessor :pgcrypto_options
+      # Public: Initializes the encryptor
+      #
+      #  options - A hash, :key is required
+      def initialize(options = {})
+        ActiveSupport.run_load_hooks(:crypt_keeper_postgres_raw_log, self)
+
+        @key = options.fetch(:key) do
+          raise ArgumentError, "Missing :key"
+        end
+
+        @iv = options[:iv]
+        @pgcrypto_options = options.fetch(:pgcrypto_options, 'aes')
+      end
+
+      # Public: Encrypts a string
+      #
+      # Returns an encrypted string
+      def encrypt(value)
+        if iv
+          escape_and_execute_sql(["SELECT encrypt_iv(?, ?, ?, ?)", value.to_s, key, iv, pgcrypto_options])['encrypt_iv']
+        else
+          escape_and_execute_sql(["SELECT encrypt(?, ?, ?)", value.to_s, key, pgcrypto_options])['encrypt']
+        end
+      end
+
+      # Public: Decrypts a string
+      #
+      # Returns a plaintext string
+      def decrypt(value)
+        if iv
+          escape_and_execute_sql(["SELECT encode(decrypt_iv(bytea(?), ?, ?, ?), 'escape')", value, key, iv, pgcrypto_options])['encode']
+        else
+          escape_and_execute_sql(["SELECT encode(decrypt(bytea(?), ?, ?), 'escape')", value, key, pgcrypto_options])['encode']
+        end
+      end
+
+      def search(records, field, criteria)
+        records.where("#{field} = ?", encrypt(criteria))
+      end
+
+    end
+  end
+end

--- a/lib/crypt_keeper/provider/postgres_raw.rb
+++ b/lib/crypt_keeper/provider/postgres_raw.rb
@@ -1,4 +1,4 @@
-require 'crypt_keeper/log_subscriber/postgres_pgp'
+require 'crypt_keeper/log_subscriber/postgres_raw'
 
 module CryptKeeper
   module Provider

--- a/spec/log_subscriber/postgres_pg_raw_spec.rb
+++ b/spec/log_subscriber/postgres_pg_raw_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 module CryptKeeper::LogSubscriber
   describe PostgresRaw do
+    before do
+      CryptKeeper.silence_logs = false
+    end
+
     use_postgres
 
     context "Without IV" do
@@ -28,7 +32,7 @@ module CryptKeeper::LogSubscriber
         "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE decrypt([FILTERED]) AND secret = 'testing'"
       end
 
-      it "filters pgp functions" do
+      it "filters postgresql_raw functions" do
         subject.should_receive(:sql_without_postgres_raw) do |event|
           event.payload[:sql].should == output_query
         end
@@ -36,7 +40,7 @@ module CryptKeeper::LogSubscriber
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
       end
 
-      it "filters pgp functions in lowercase" do
+      it "filters postgresql_raw functions in lowercase" do
         subject.should_receive(:sql_without_postgres_raw) do |event|
           event.payload[:sql].should == output_query.downcase.gsub(/filtered/, 'FILTERED')
         end
@@ -44,7 +48,7 @@ module CryptKeeper::LogSubscriber
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query.downcase }))
       end
 
-      it "filters pgp functions when searching" do
+      it "filters postgresql_raw functions when searching" do
         subject.should_receive(:sql_without_postgres_raw) do |event|
           event.payload[:sql].should == output_search_query
         end
@@ -55,6 +59,12 @@ module CryptKeeper::LogSubscriber
       it "forces string encodings" do
         string_encoding_query = "SELECT encrypt('hi \255', 'test', 'aes')"
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: string_encoding_query }))
+      end
+
+      it "skips logging if CryptKeeper.silence_logs is set" do
+        CryptKeeper.silence_logs = true
+        subject.should_not_receive(:sql_without_postgres_raw)
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
       end
     end
 
@@ -82,7 +92,7 @@ module CryptKeeper::LogSubscriber
         "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE decrypt([FILTERED]) AND secret = 'testing'"
       end
 
-      it "filters pgp functions" do
+      it "filters postgresql_raw functions" do
         subject.should_receive(:sql_without_postgres_raw) do |event|
           event.payload[:sql].should == output_query
         end
@@ -90,7 +100,7 @@ module CryptKeeper::LogSubscriber
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
       end
 
-      it "filters pgp functions in lowercase" do
+      it "filters postgresql_raw functions in lowercase" do
         subject.should_receive(:sql_without_postgres_raw) do |event|
           event.payload[:sql].should == output_query.downcase.gsub(/filtered/, 'FILTERED')
         end
@@ -98,7 +108,7 @@ module CryptKeeper::LogSubscriber
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query.downcase }))
       end
 
-      it "filters pgp functions when searching" do
+      it "filters postgresql_raw functions when searching" do
         subject.should_receive(:sql_without_postgres_raw) do |event|
           event.payload[:sql].should == output_search_query
         end
@@ -109,6 +119,12 @@ module CryptKeeper::LogSubscriber
       it "forces string encodings" do
         string_encoding_query = "SELECT encrypt('hi \255', 'test', 'aes')"
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: string_encoding_query }))
+      end
+
+      it "skips logging if CryptKeeper.silence_logs is set" do
+        CryptKeeper.silence_logs = true
+        subject.should_not_receive(:sql_without_postgres_raw)
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
       end
     end
   end

--- a/spec/log_subscriber/postgres_pg_raw_spec.rb
+++ b/spec/log_subscriber/postgres_pg_raw_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+module CryptKeeper::LogSubscriber
+  describe PostgresRaw do
+    use_postgres
+
+    context "Without IV" do
+      # Fire the ActiveSupport.on_load
+      before do
+        CryptKeeper::Provider::PostgresRaw.new key: 'secret'
+      end
+
+      subject { ::ActiveRecord::LogSubscriber.new }
+
+      let(:input_query) do
+        "SELECT encrypt('encrypt_value', 'encrypt_key', 'encrypt_option'), encode(decrypt('decrypt_value', 'decrypt_key', 'decrypt_option'), 'escape') FROM DUAL;"
+      end
+
+      let(:output_query) do
+        "SELECT encrypt([FILTERED]) FROM DUAL;"
+      end
+
+      let(:input_search_query) do
+        "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE encode(decrypt('decrypt_value', 'decrypt_key', 'decrypt_option'), 'escape') AND secret = 'testing'"
+      end
+
+      let(:output_search_query) do
+        "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE decrypt([FILTERED]) AND secret = 'testing'"
+      end
+
+      it "filters pgp functions" do
+        subject.should_receive(:sql_without_postgres_raw) do |event|
+          event.payload[:sql].should == output_query
+        end
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
+      end
+
+      it "filters pgp functions in lowercase" do
+        subject.should_receive(:sql_without_postgres_raw) do |event|
+          event.payload[:sql].should == output_query.downcase.gsub(/filtered/, 'FILTERED')
+        end
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query.downcase }))
+      end
+
+      it "filters pgp functions when searching" do
+        subject.should_receive(:sql_without_postgres_raw) do |event|
+          event.payload[:sql].should == output_search_query
+        end
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_search_query }))
+      end
+
+      it "forces string encodings" do
+        string_encoding_query = "SELECT encrypt('hi \255', 'test', 'aes')"
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: string_encoding_query }))
+      end
+    end
+
+    context "With IV" do
+      # Fire the ActiveSupport.on_load
+      before do
+        CryptKeeper::Provider::PostgresRaw.new key: 'secret'
+      end
+
+      subject { ::ActiveRecord::LogSubscriber.new }
+
+      let(:input_query) do
+        "SELECT encrypt_iv('encrypt_value', 'encrypt_key', 'encrypt_option'), encode(decrypt_iv('decrypt_value', 'decrypt_key', 'decrypt_option'), 'escape') FROM DUAL;"
+      end
+
+      let(:output_query) do
+        "SELECT encrypt([FILTERED]) FROM DUAL;"
+      end
+
+      let(:input_search_query) do
+        "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE encode(decrypt_iv('decrypt_value', 'decrypt_key', 'decrypt_option'), 'escape') AND secret = 'testing'"
+      end
+
+      let(:output_search_query) do
+        "SELECT \"sensitive_data\".* FROM \"sensitive_data\" WHERE decrypt([FILTERED]) AND secret = 'testing'"
+      end
+
+      it "filters pgp functions" do
+        subject.should_receive(:sql_without_postgres_raw) do |event|
+          event.payload[:sql].should == output_query
+        end
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
+      end
+
+      it "filters pgp functions in lowercase" do
+        subject.should_receive(:sql_without_postgres_raw) do |event|
+          event.payload[:sql].should == output_query.downcase.gsub(/filtered/, 'FILTERED')
+        end
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query.downcase }))
+      end
+
+      it "filters pgp functions when searching" do
+        subject.should_receive(:sql_without_postgres_raw) do |event|
+          event.payload[:sql].should == output_search_query
+        end
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_search_query }))
+      end
+
+      it "forces string encodings" do
+        string_encoding_query = "SELECT encrypt('hi \255', 'test', 'aes')"
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: string_encoding_query }))
+      end
+    end
+  end
+end

--- a/spec/provider/postgres_raw_spec.rb
+++ b/spec/provider/postgres_raw_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+module CryptKeeper
+  module Provider
+    describe PostgresRaw do
+      use_postgres
+
+      describe 'Without IV' do
+        let(:cipher_text) { '\x78993a3c66d15ff843fda92766fb96bd' }
+        let(:plain_text)  { 'test' }
+        let(:integer_cipher_text) { '\xe4c205b8ccf0d53666f2d19341ab2e41' }
+        let(:integer_plain_text) { 1 }
+
+        subject { PostgresRaw.new key: ENCRYPTION_PASSWORD }
+
+        its(:key) { should == ENCRYPTION_PASSWORD }
+
+        describe "#initialize" do
+          specify { expect { PostgresRaw.new }.to raise_error(ArgumentError, "Missing :key") }
+        end
+
+        describe "#encrypt" do
+          context "Strings" do
+            specify { subject.encrypt(plain_text).should_not == plain_text }
+            specify { subject.encrypt(plain_text).should_not be_empty }
+          end
+
+          context "Integers" do
+            specify { subject.encrypt(integer_plain_text).should_not == integer_plain_text }
+            specify { subject.encrypt(integer_plain_text).should_not be_empty }
+          end
+        end
+
+        describe "#decrypt" do
+          specify { subject.decrypt(cipher_text).should == plain_text }
+          specify { subject.decrypt(integer_cipher_text).should == integer_plain_text.to_s }
+        end
+
+        describe "#search" do
+          subject { postgres_model }
+
+          it "finds the matching record" do
+            subject.create!(storage: 'blah2')
+            match = subject.create!(storage: 'blah')
+            subject.search_by_plaintext(:storage, 'blah').first.should == match
+          end
+        end
+
+        describe "Custom pgcrypto options" do
+          let(:pgcrypto_options) { 'bf-cbc/pad:pkcs' }
+
+          subject { PostgresRaw.new key: 'candy', pgcrypto_options: pgcrypto_options }
+
+          it "reads and writes" do
+            queries = logged_queries do
+              encrypted = subject.encrypt(plain_text)
+              subject.decrypt(encrypted).should == plain_text
+            end
+
+            queries.should_not be_empty
+
+            queries.select { |query| query.include?("encrypt") || query.include?("decrypt")}.each do |q|
+              q.should include(pgcrypto_options)
+            end
+          end
+        end
+      end
+
+      describe 'With IV' do
+        let(:iv) { 'anothersupermadsecretstring' }
+        let(:cipher_text) { '\x7d468abaab79d8b329b49ecdb7c8a4a7' }
+        let(:plain_text)  { 'test' }
+        let(:integer_cipher_text) { '\xa8d80852a831597af8ae1eb5d8964175' }
+        let(:integer_plain_text) { 1 }
+
+        subject { PostgresRaw.new key: ENCRYPTION_PASSWORD, iv: iv }
+
+        its(:key) { should == ENCRYPTION_PASSWORD }
+
+        describe "#initialize" do
+          specify { expect { PostgresRaw.new }.to raise_error(ArgumentError, "Missing :key") }
+        end
+
+        describe "#encrypt" do
+          context "Strings" do
+            specify { subject.encrypt(plain_text).should_not == plain_text }
+            specify { subject.encrypt(plain_text).should_not be_empty }
+          end
+
+          context "Integers" do
+            specify { subject.encrypt(integer_plain_text).should_not == integer_plain_text }
+            specify { subject.encrypt(integer_plain_text).should_not be_empty }
+          end
+        end
+
+        describe "#decrypt" do
+          specify { subject.decrypt(cipher_text).should == plain_text }
+          specify { subject.decrypt(integer_cipher_text).should == integer_plain_text.to_s }
+        end
+
+        describe "#search" do
+          subject { postgres_model }
+
+          it "finds the matching record" do
+            subject.create!(storage: 'blah2')
+            match = subject.create!(storage: 'blah')
+            subject.search_by_plaintext(:storage, 'blah').first.should == match
+          end
+        end
+
+        describe "Custom pgcrypto options" do
+          let(:pgcrypto_options) { 'bf-cbc/pad:pkcs' }
+
+          subject { PostgresRaw.new key: 'candy', iv: iv, pgcrypto_options: pgcrypto_options }
+
+          it "reads and writes" do
+            queries = logged_queries do
+              encrypted = subject.encrypt(plain_text)
+              subject.decrypt(encrypted).should == plain_text
+            end
+
+            queries.should_not be_empty
+
+            queries.select { |query| query.include?("encrypt") || query.include?("decrypt")}.each do |q|
+              q.should include(pgcrypto_options)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why PostgreSQL's Raw Encryption?**

Although in the PostgreSQL's documentation the raw encryption is said as less recommended than pgp, it has its own advantages. In database encryption, flexibility and security are two sides on a balance. If a project with PostgreSQL requires both encryption and quick search function, the raw encryption seems the only choice. Searching in pgp from 1,000 records brings a major performance issue. 

I love PostgreSQL and crypt_keeper (esp. its simplicity) to do encryption, and don't want to give up any of them.
