### PR TITLE
Allow silencing logging completely

### DIFF
--- a/gemfiles/activerecord_4_1.gemfile.lock
+++ b/gemfiles/activerecord_4_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.20.0)
+    crypt_keeper (0.21.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)
@@ -117,4 +117,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/gemfiles/activerecord_4_2.gemfile.lock
+++ b/gemfiles/activerecord_4_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    crypt_keeper (0.20.0)
+    crypt_keeper (0.21.0)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
       aes (~> 0.5.0)
@@ -117,4 +117,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/lib/crypt_keeper.rb
+++ b/lib/crypt_keeper.rb
@@ -13,7 +13,10 @@ require 'crypt_keeper/provider/postgres_pgp_public_key'
 module CryptKeeper
   class << self
     attr_accessor :stub_encryption
-    alias_method :stub_encryption?, :stub_encryption 
+    alias_method :stub_encryption?, :stub_encryption
+
+    attr_accessor :silence_logs
+    alias_method :silence_logs?, :silence_logs
   end
 end
 

--- a/lib/crypt_keeper/log_subscriber/mysql_aes.rb
+++ b/lib/crypt_keeper/log_subscriber/mysql_aes.rb
@@ -16,6 +16,8 @@ module CryptKeeper
         payload = event.payload[:sql]
           .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
 
+        return if CryptKeeper.silence_logs? && payload =~ filter
+
         event.payload[:sql] = payload.gsub(filter) do |_|
           "#{$1}([FILTERED])"
         end

--- a/lib/crypt_keeper/log_subscriber/postgres_pgp.rb
+++ b/lib/crypt_keeper/log_subscriber/postgres_pgp.rb
@@ -16,6 +16,8 @@ module CryptKeeper
         payload = event.payload[:sql]
           .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
 
+        return if CryptKeeper.silence_logs? && payload =~ filter
+
         event.payload[:sql] = payload.gsub(filter) do |_|
           "#{$~[:operation]}([FILTERED])"
         end

--- a/spec/log_subscriber/mysql_aes_spec.rb
+++ b/spec/log_subscriber/mysql_aes_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 module CryptKeeper::LogSubscriber
   describe MysqlAes do
+    before do
+      CryptKeeper.silence_logs = false
+    end
+
     use_mysql
 
     context "AES encryption" do
@@ -55,6 +59,14 @@ module CryptKeeper::LogSubscriber
       it "forces string encodings" do
         string_encoding_query = "SELECT aes_encrypt('hi \255', 'test')"
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: string_encoding_query }))
+      end
+
+      it "skips logging if CryptKeeper.silence_logs is set" do
+        CryptKeeper.silence_logs = true
+
+        subject.should_not_receive(:sql_without_mysql_aes)
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
       end
     end
   end

--- a/spec/log_subscriber/postgres_pgp_spec.rb
+++ b/spec/log_subscriber/postgres_pgp_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 module CryptKeeper::LogSubscriber
   describe PostgresPgp do
+    before do
+      CryptKeeper.silence_logs = false
+    end
+
     use_postgres
 
     context "Symmetric encryption" do
@@ -56,6 +60,14 @@ module CryptKeeper::LogSubscriber
         string_encoding_query = "SELECT pgp_sym_encrypt('hi \255', 'test')"
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: string_encoding_query }))
       end
+
+      it "skips logging if CryptKeeper.silence_logs is set" do
+        CryptKeeper.silence_logs = true
+
+        subject.should_not_receive(:sql_without_postgres_pgp)
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
+      end
     end
 
     context "Public key encryption" do
@@ -97,6 +109,14 @@ module CryptKeeper::LogSubscriber
         end
 
         subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query.downcase }))
+      end
+
+      it "skips logging if CryptKeeper.silence_logs is set" do
+        CryptKeeper.silence_logs = true
+
+        subject.should_not_receive(:sql_without_postgres_pgp)
+
+        subject.sql(ActiveSupport::Notifications::Event.new(:sql, 1, 1, 1, { sql: input_query }))
       end
     end
   end


### PR DESCRIPTION
Example:

```
> Foo.first; nil
  Foo Load (1.2ms)  SELECT  "foos".* FROM "foos"  ORDER BY "foos"."id" ASC LIMIT 1
   (0.7ms)  SELECT decrypt([FILTERED])
> CryptKeeper.silence_logging = true
> Foo.first; nil
  Foo Load (1.2ms)  SELECT  "foos".* FROM "foos"  ORDER BY "foos"."id" ASC LIMIT 1
```