### PR TITLE
rake test for generating testing database

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,8 @@ Or install it yourself as:
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+### Running Tests
+1. Create your own `database.yml` from `default.database.yml`.
+2. Create testing databases by `bundle exec rake db:create`
+3. Run the test suite by `bundle exec rspec`

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,30 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require 'active_record'
 require 'rspec/core/rake_task'
 require 'appraisal'
+require 'pg'
 
 RSpec::Core::RakeTask.new :spec
 Bundler::GemHelper.install_tasks
 
 task :default => [:spec]
+
+namespace :db do
+  desc "Loads the database configuration from database yml."
+  task :load_config do
+    ActiveRecord::Tasks::DatabaseTasks.root = File.dirname(__FILE__)
+    ActiveRecord::Base.configurations = YAML.load_file("#{File.dirname(__FILE__)}/spec/database.yml") || {}
+  end
+
+  desc "Creates the database from activerecord base configuration."
+  task create: [:load_config] do
+    ActiveRecord::Base.configurations.each do |adapter, config|
+      ActiveRecord::Tasks::DatabaseTasks.create_current(adapter)
+      if adapter == 'postgres'
+        conn = PG::Connection.open(dbname: config['database'])
+        conn.exec('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I am not sure what's the best way to set up testing environment for crypt_keeper. I spent some time to manually create databases and add postgresql extensions, for every machine.

The new rake test is to make it done by running `rake db:create` as how we do for rails from `database.yml`