### PR TITLE
Quote column name to prevent reserved word issues

### DIFF
--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -36,7 +36,7 @@ module CryptKeeper
       end
 
       def search(records, field, criteria)
-        records.where("(pgp_sym_decrypt(cast(#{field} AS bytea), ?) = ?)", key, criteria)
+        records.where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)", key, criteria)
       end
     end
   end


### PR DESCRIPTION
We have a column name of `full` which triggers #103. Surrounding the column name with quotes seems to resolve this issue.