### PR TITLE
Add `bytea` as a valid column type

### DIFF
--- a/lib/crypt_keeper/model.rb
+++ b/lib/crypt_keeper/model.rb
@@ -10,8 +10,9 @@ module CryptKeeper
     def ensure_valid_field!(field)
       if self.class.columns_hash["#{field}"].nil?
         raise ArgumentError, "Column :#{field} does not exist"
-      elsif self.class.columns_hash["#{field}"].type != :text
-        raise ArgumentError, "Column :#{field} must be of type 'text' to be used for encryption"
+      elsif !%i(text binary).include?(self.class.columns_hash["#{field}"].type)
+        raise ArgumentError, "Column :#{field} must be of type 'text' or 'binary' \
+to be used for encryption"
       end
     end
 

--- a/spec/crypt_keeper/model_spec.rb
+++ b/spec/crypt_keeper/model_spec.rb
@@ -24,8 +24,14 @@ describe CryptKeeper::Model do
         expect { subject.new.save }.to raise_error(ArgumentError, msg)
       end
 
-      it "raises an exception for non text fields" do
-        msg = "Column :name must be of type 'text' to be used for encryption"
+      it "allows binary as a valid type" do
+        subject.crypt_keeper :storage, encryptor: :fake_encryptor
+        allow(subject.columns_hash['storage']).to receive(:type).and_return(:binary)
+        expect(subject.new.save).to be_truthy
+      end
+
+      it "raises an exception for non text or binary fields" do
+        msg = "Column :name must be of type 'text' or 'binary' to be used for encryption"
         subject.crypt_keeper :name, encryptor: :fake_encryptor
         expect { subject.new.save }.to raise_error(ArgumentError, msg)
       end


### PR DESCRIPTION
Hi!
As part of PostgreSQL documentation for [pgcrypto](https://www.postgresql.org/docs/9.6/static/pgcrypto.html#AEN181287), `pgp_pub_encrypt()` return a `bytea` and `pgp_pub_decrypt()` takes a `bytea`.
Since PostgreSQL has a [bytea](https://www.postgresql.org/docs/9.6/static/datatype-binary.html) data type, it looks legit that `crypt_keeper` should also allow this type along with the existing `text`.
I think this change should be safe even for other DBs with no such type (like MySQL), because the migration would not even allow the creation of the column.
Let me know what you think!