### PR TITLE
Filters sql from ActiveRecord::StatementInvalid

### DIFF
--- a/lib/crypt_keeper/log_subscriber/postgres_pgp.rb
+++ b/lib/crypt_keeper/log_subscriber/postgres_pgp.rb
@@ -4,23 +4,43 @@ require 'active_support/lazy_load_hooks'
 module CryptKeeper
   module LogSubscriber
     module PostgresPgp
+      FILTER = /(\(*)pgp_(sym|pub)_(?<operation>decrypt|encrypt)(\(+.*\)+)/im
+
       # Public: Prevents sensitive data from being logged
       #
       # event - An ActiveSupport::Notifications::Event
       #
       # Returns a boolean.
       def sql(event)
-        filter  = /(\(*)pgp_(sym|pub)_(?<operation>decrypt|encrypt)(\(+.*\)+)/im
-        payload = event.payload[:sql]
-          .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+        payload = crypt_keeper_payload_parse(event.payload[:sql])
 
-        return if CryptKeeper.silence_logs? && payload =~ filter
+        return if CryptKeeper.silence_logs? && payload =~ FILTER
 
-        event.payload[:sql] = payload.gsub(filter) do |_|
+        event.payload[:sql] = crypt_keeper_filter_postgres_log(payload)
+        super(event)
+      end
+
+      private
+
+      # Private: Parses the payload to UTF.
+      #
+      # payload - the payload string
+      #
+      # Returns a string.
+      def crypt_keeper_payload_parse(payload)
+        payload.encode('UTF-8', 'binary',
+          invalid: :replace, undef: :replace, replace: '')
+      end
+
+      # Private: Filters the payload.
+      #
+      # payload - the payload string
+      #
+      # Returns a string.
+      def crypt_keeper_filter_postgres_log(payload)
+        payload.gsub(FILTER) do |_|
           "#{$~[:operation]}([FILTERED])"
         end
-
-        super(event)
       end
     end
   end

--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -4,6 +4,7 @@ module CryptKeeper
   module Provider
     class PostgresPgp < Base
       include CryptKeeper::Helper::SQL
+      include CryptKeeper::LogSubscriber::PostgresPgp
 
       attr_accessor :key
       attr_accessor :pgcrypto_options
@@ -25,18 +26,37 @@ module CryptKeeper
       #
       # Returns an encrypted string
       def encrypt(value)
-        escape_and_execute_sql(["SELECT pgp_sym_encrypt(?, ?, ?)", value.to_s, key, pgcrypto_options])['pgp_sym_encrypt']
+        rescue_invalid_statement do
+          escape_and_execute_sql(["SELECT pgp_sym_encrypt(?, ?, ?)",
+            value.to_s, key, pgcrypto_options])['pgp_sym_encrypt']
+        end
       end
 
       # Public: Decrypts a string
       #
       # Returns a plaintext string
       def decrypt(value)
-        escape_and_execute_sql(["SELECT pgp_sym_decrypt(?, ?)", value, key])['pgp_sym_decrypt']
+        rescue_invalid_statement do
+          escape_and_execute_sql(["SELECT pgp_sym_decrypt(?, ?)",
+            value, key])['pgp_sym_decrypt']
+        end
       end
 
       def search(records, field, criteria)
-        records.where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)", key, criteria)
+        records.where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)",
+          key, criteria)
+      end
+
+      private
+
+      # Private: Rescues and filters invalid statement errors. Run the code
+      # within a block for it to be rescued.
+      def rescue_invalid_statement
+        yield
+      rescue ActiveRecord::StatementInvalid => e
+        message = crypt_keeper_payload_parse(e.message)
+        message = crypt_keeper_filter_postgres_log(message)
+        raise ActiveRecord::StatementInvalid, message
       end
     end
   end

--- a/lib/crypt_keeper/version.rb
+++ b/lib/crypt_keeper/version.rb
@@ -1,3 +1,3 @@
 module CryptKeeper
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/crypt_keeper/provider/postgres_pgp_spec.rb
+++ b/spec/crypt_keeper/provider/postgres_pgp_spec.rb
@@ -28,11 +28,31 @@ describe CryptKeeper::Provider::PostgresPgp do
       specify { expect(subject.encrypt(integer_plain_text)).to_not eq(integer_plain_text) }
       specify { expect(subject.encrypt(integer_plain_text)).to_not be_empty }
     end
+
+    it "filters StatementInvalid errors" do
+      subject.pgcrypto_options = "invalid"
+
+      begin
+        subject.encrypt(plain_text)
+      rescue ActiveRecord::StatementInvalid => e
+        expect(e.message).to_not include("invalid")
+        expect(e.message).to_not include(ENCRYPTION_PASSWORD)
+      end
+    end
   end
 
   describe "#decrypt" do
     specify { expect(subject.decrypt(cipher_text)).to eq(plain_text) }
     specify { expect(subject.decrypt(integer_cipher_text)).to eq(integer_plain_text.to_s) }
+
+    it "filters StatementInvalid errors" do
+      begin
+        subject.decrypt("invalid")
+      rescue ActiveRecord::StatementInvalid => e
+        expect(e.message).to_not include("invalid")
+        expect(e.message).to_not include(ENCRYPTION_PASSWORD)
+      end
+    end
   end
 
   describe "#search" do


### PR DESCRIPTION
This updates the postgres provider to filter ActiveRecord::StatementInvalid messages to remove the keys.

This was the simplest fix I could come up with for `encrypt` and `decrypt`. The `search` method is harder, because that returns an `ActiveRecord::Relation`, and the query is only triggered at a later point, so we can't easily rescue.

I think a better fix for this would be to move them all to use sql prepared statements instead of raw sql, that way the exception would only get the prepared statement query without any actual keys. I started looking into that, but this path would need more changes on crypt keeper, so I changed to this simpler fix for now instead (https://github.com/fabiokr/crypt_keeper/pull/1 log messages would be different, would have to reworks the log subscriber, etc).