### PR TITLE
Allows setting a fallback key for the PostgresPgp decryptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1.10
   - 2.2.5
   - 2.3.1
+  - 2.4.2
 
 gemfile:
   - gemfiles/activerecord_4_2.gemfile

--- a/lib/crypt_keeper/helper.rb
+++ b/lib/crypt_keeper/helper.rb
@@ -6,33 +6,27 @@ module CryptKeeper
       # Private: Sanitize an sql query and then execute it.
       #
       # query - the sql query
-      # new_transaction - if the query should run inside a new transaction
       #
       # Returns the ActiveRecord response.
-      def escape_and_execute_sql(query, new_transaction: false)
+      def escape_and_execute_sql(query)
         query = ::ActiveRecord::Base.send :sanitize_sql_array, query
 
         if CryptKeeper.silence_logs?
           ::ActiveRecord::Base.logger.silence do
-            execute_sql(query, new_transaction: new_transaction)
+            execute_sql(query)
           end
         else
-          execute_sql(query, new_transaction: new_transaction)
+          execute_sql(query)
         end
       end
 
       # Private: Executes the query.
       #
       # query - the sql query
-      # new_transaction - if the query should run inside a new transaction
       #
       # Returns an Array.
-      def execute_sql(query, new_transaction: false)
-        if new_transaction
-          ::ActiveRecord::Base.transaction(requires_new: true) do
-            ::ActiveRecord::Base.connection.execute(query).first
-          end
-        else
+      def execute_sql(query)
+        ::ActiveRecord::Base.transaction(requires_new: true) do
           ::ActiveRecord::Base.connection.execute(query).first
         end
       end

--- a/lib/crypt_keeper/provider/postgres_base.rb
+++ b/lib/crypt_keeper/provider/postgres_base.rb
@@ -13,8 +13,9 @@ module CryptKeeper
       # Returns boolean
       def encrypted?(value)
         begin
-          escape_and_execute_sql(["SELECT pgp_key_id(?)", value.to_s],
-            new_transaction: true)['pgp_key_id'].present?
+          escape_and_execute_sql([
+            "SELECT pgp_key_id(?)", value.to_s
+          ])['pgp_key_id'].present?
         rescue ActiveRecord::StatementInvalid => e
           if e.message.include?(INVALID_DATA_ERROR)
             false

--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -2,17 +2,24 @@ module CryptKeeper
   module Provider
     class PostgresPgp < PostgresBase
       attr_accessor :key
+      attr_accessor :fallback_key
       attr_accessor :pgcrypto_options
 
       # Public: Initializes the encryptor
       #
-      #  options - A hash, :key is required
+      #  options - A hash of options.
+      #    key - the encryption key (required)
+      #    fallback_key - an alternative key to fallback to if decrypting using
+      #                   `key` fails
+      #    pgcrypto_options - custom options for pgcrypto
       def initialize(options = {})
         ActiveSupport.run_load_hooks(:crypt_keeper_postgres_pgp_log, self)
 
         @key = options.fetch(:key) do
           raise ArgumentError, "Missing :key"
         end
+
+        @fallback_key = options.fetch(:fallback_key, nil)
 
         @pgcrypto_options = options.fetch(:pgcrypto_options, '')
       end
@@ -33,8 +40,15 @@ module CryptKeeper
       def decrypt(value)
         rescue_invalid_statement do
           if encrypted?(value)
-            escape_and_execute_sql(["SELECT pgp_sym_decrypt(?, ?)",
-              value, key])['pgp_sym_decrypt']
+            begin
+              execute_decrypt(value, key)
+            rescue ActiveRecord::StatementInvalid
+              if fallback_key.present?
+                execute_decrypt(value, fallback_key)
+              else
+                raise
+              end
+            end
           else
             value
           end
@@ -47,6 +61,14 @@ module CryptKeeper
       end
 
       private
+
+      # Private: Decrypts a string.
+      #
+      # Returns a plaintext string
+      def execute_decrypt(value, key)
+        escape_and_execute_sql(["SELECT pgp_sym_decrypt(?, ?)",
+          value, key])['pgp_sym_decrypt']
+      end
 
       # Private: Rescues and filters invalid statement errors. Run the code
       # within a block for it to be rescued.

--- a/spec/crypt_keeper/provider/postgres_pgp_spec.rb
+++ b/spec/crypt_keeper/provider/postgres_pgp_spec.rb
@@ -54,6 +54,17 @@ describe CryptKeeper::Provider::PostgresPgp do
         expect(e.message).to_not include(ENCRYPTION_PASSWORD)
       end
     end
+
+    context "with fallback key" do
+      let(:fallback_cipher_text) { '\xc30d040703026366dd2927a800726ed235010ac8e27923e3b6636f8e0d81068015e3a2aacf40e2c9a40b06022b9d574e8616cceeacb4a345ee4ddbf30ea8c1f006c9b41ce265' }
+      let(:fallback_integer_cypher_text) { '\xc30d04070302b774cafc9795e64c74d232010f568008cbd5e5362f38f7c3ce6356f1e4052bee2de34d7fa32db8501ab7510738e8adcdf9e62bf47a224fd710a0334751' }
+
+      subject { described_class.new key: ENCRYPTION_PASSWORD, fallback_key: FALLBACK_ENCRYPTION_PASSWORD }
+
+      specify { expect(subject.decrypt(fallback_cipher_text)).to eq(plain_text) }
+      specify { expect(subject.decrypt(fallback_integer_cypher_text)).to eq(integer_plain_text.to_s) }
+      specify { expect(subject.decrypt(plain_text)).to eq(plain_text) }
+    end
   end
 
   describe "#search" do

--- a/spec/crypt_keeper/provider/postgres_pgp_spec.rb
+++ b/spec/crypt_keeper/provider/postgres_pgp_spec.rb
@@ -7,8 +7,9 @@ describe CryptKeeper::Provider::PostgresPgp do
   let(:plain_text)  { 'test' }
 
   let(:integer_cipher_text) { '\xc30d04070302c8d266353bcf2fc07dd23201153f9d9c32fbb3c36b9b0db137bf8b6c609172210d89ded63f11dff23d1ddbf5111c0266549dde26175c4425e06bb4bd6f' }
-
   let(:integer_plain_text) { 1 }
+
+  let(:invalid_cipher) { '\xc30d040703026366dd2927a800726ed235010ac8e27923e3b6636f8e0d81068015e3a2aacf40e2c9a40b06022b9d574e8616cceeacb4a345ee4ddbf30ea8c1f006c9b41ce333' }
 
   subject { described_class.new key: ENCRYPTION_PASSWORD }
 
@@ -47,10 +48,12 @@ describe CryptKeeper::Provider::PostgresPgp do
     specify { expect(subject.decrypt(plain_text)).to eq(plain_text) }
 
     it "filters StatementInvalid errors" do
+      expect { subject.decrypt(invalid_cipher) }
+        .to raise_error(ActiveRecord::StatementInvalid)
+
       begin
-        subject.decrypt("invalid")
+        subject.decrypt(invalid_cipher)
       rescue ActiveRecord::StatementInvalid => e
-        expect(e.message).to_not include("invalid")
         expect(e.message).to_not include(ENCRYPTION_PASSWORD)
       end
     end
@@ -64,6 +67,21 @@ describe CryptKeeper::Provider::PostgresPgp do
       specify { expect(subject.decrypt(fallback_cipher_text)).to eq(plain_text) }
       specify { expect(subject.decrypt(fallback_integer_cypher_text)).to eq(integer_plain_text.to_s) }
       specify { expect(subject.decrypt(plain_text)).to eq(plain_text) }
+
+      it "filters StatementInvalid errors" do
+        expect { subject.decrypt(invalid_cipher) }
+          .to raise_error(ActiveRecord::StatementInvalid)
+
+        begin
+          subject.decrypt(invalid_cipher)
+        rescue ActiveRecord::StatementInvalid => e
+          expect(e.message).to_not include(ENCRYPTION_PASSWORD)
+          expect(e.message).to_not include(FALLBACK_ENCRYPTION_PASSWORD)
+
+          # make sure we avoid a `cause` for the exception
+          expect(e.cause).to be_nil
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,10 @@ require 'coveralls'
 Coveralls.wear!
 require 'crypt_keeper'
 
-SPEC_ROOT           = Pathname.new File.expand_path File.dirname __FILE__
-AR_LOG              = SPEC_ROOT.join('debug.log').to_s
-ENCRYPTION_PASSWORD = "supermadsecretstring"
+SPEC_ROOT                    = Pathname.new File.expand_path File.dirname __FILE__
+AR_LOG                       = SPEC_ROOT.join('debug.log').to_s
+ENCRYPTION_PASSWORD          = "supermadsecretstring"
+FALLBACK_ENCRYPTION_PASSWORD = "fallbacksecretstring"
 
 Dir[SPEC_ROOT.join('support/*.rb')].each{|f| require f }
 


### PR DESCRIPTION
This can be used when needing to rotate keys for example. By configuring
a fallback key, you can setup a new key that is used for new
encryptions. For decryptions, it will try to decrypt using the key
first. If that fails, it will also try using the fallback key.