### PR TITLE
Bump version to 2.0.0.rc1

### DIFF
--- a/lib/crypt_keeper/version.rb
+++ b/lib/crypt_keeper/version.rb
@@ -1,3 +1,3 @@
 module CryptKeeper
-  VERSION = "1.1.1"
+  VERSION = "2.0.0.rc1"
 end


### PR DESCRIPTION
Note that 2.0.0 contains [breaking changes](https://github.com/jmazzi/crypt_keeper/pull/140) for users of the `aes_new` encryptor. Data will need to be re-encrypted.

Steps from the README:

## Migrating from CryptKeeper 1.x to 2.0

CryptKeeper 2.0 removes the AES encryptor due to security issues in the
underlying AES gem. If you were previously using the `aes_new` encryptor, you
will need to follow these instructions to reencrypt your data.

The general migration path is as follows:

1. Enable maintenance mode in any live apps
2. Backup database
3. Decrypt tables: TableName.decrypt_table!
4. Update to 2.0.0.rc1 in your app. Update the encryptor to use :active_support
5. Encrypt tables: `TableName.encrypt_table!`
6. Verify data can be decrypted: `TableName.first`
7. Disable maintenance mode if necessary

In case you experience problems, the rollback procedure is as follows:

1. Enable maintenance mode
2. Backup database again
3. Restore first database dump, from before CryptKeeper 2.0.0.rc1
4. Verify data can be decrypted
5. Disable maintenance mode
6. Let us know what happened :(