### PR TITLE
Prepend 'public' schema to all postgres PGP calls

### DIFF
--- a/lib/crypt_keeper/provider/postgres_base.rb
+++ b/lib/crypt_keeper/provider/postgres_base.rb
@@ -13,7 +13,7 @@ module CryptKeeper
       # Returns boolean
       def encrypted?(value)
         begin
-          escape_and_execute_sql(["SELECT pgp_key_id(?)", value.to_s],
+          escape_and_execute_sql(["SELECT \"public\".pgp_key_id(?)", value.to_s],
             new_transaction: true)['pgp_key_id'].present?
         rescue ActiveRecord::StatementInvalid => e
           if e.message.include?(INVALID_DATA_ERROR)

--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -22,7 +22,7 @@ module CryptKeeper
       # Returns an encrypted string
       def encrypt(value)
         rescue_invalid_statement do
-          escape_and_execute_sql(["SELECT pgp_sym_encrypt(?, ?, ?)",
+          escape_and_execute_sql(["SELECT \"public\".pgp_sym_encrypt(?, ?, ?)",
             value.to_s, key, pgcrypto_options])['pgp_sym_encrypt']
         end
       end
@@ -33,7 +33,7 @@ module CryptKeeper
       def decrypt(value)
         rescue_invalid_statement do
           if encrypted?(value)
-            escape_and_execute_sql(["SELECT pgp_sym_decrypt(?, ?)",
+            escape_and_execute_sql(["SELECT \"public\".pgp_sym_decrypt(?, ?)",
               value, key])['pgp_sym_decrypt']
           else
             value
@@ -42,7 +42,7 @@ module CryptKeeper
       end
 
       def search(records, field, criteria)
-        records.where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)",
+        records.where("(\"public\".pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)",
           key, criteria)
       end
 

--- a/lib/crypt_keeper/provider/postgres_pgp_public_key.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp_public_key.rb
@@ -21,7 +21,7 @@ module CryptKeeper
         if !@private_key.present? && encrypted?(value)
           value
         else
-          escape_and_execute_sql(["SELECT pgp_pub_encrypt(?, dearmor(?))", value.to_s, @public_key])['pgp_pub_encrypt']
+          escape_and_execute_sql(["SELECT \"public\".pgp_pub_encrypt(?, \"public\".dearmor(?))", value.to_s, @public_key])['pgp_pub_encrypt']
         end
       end
 
@@ -30,7 +30,7 @@ module CryptKeeper
       # Returns a plaintext string
       def decrypt(value)
         if @private_key.present? && encrypted?(value)
-          escape_and_execute_sql(["SELECT pgp_pub_decrypt(?, dearmor(?), ?)",
+          escape_and_execute_sql(["SELECT \"public\".pgp_pub_decrypt(?, dearmor(?), ?)",
             value, @private_key, @key])['pgp_pub_decrypt']
         else
           value

--- a/lib/crypt_keeper/provider/postgres_pgp_public_key.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp_public_key.rb
@@ -30,7 +30,7 @@ module CryptKeeper
       # Returns a plaintext string
       def decrypt(value)
         if @private_key.present? && encrypted?(value)
-          escape_and_execute_sql(["SELECT \"public\".pgp_pub_decrypt(?, dearmor(?), ?)",
+          escape_and_execute_sql(["SELECT \"public\".pgp_pub_decrypt(?, \"public\".dearmor(?), ?)",
             value, @private_key, @key])['pgp_pub_decrypt']
         else
           value


### PR DESCRIPTION
The Postgres PGP functions live in the "public" schema, which causes an exception if crypt_keeper is used after the schema search_path has been set by a multi-tenancy solution like https://github.com/influitive/apartment

This PR fixes this by prepending "public" to all Postgres PGP function calls.

Thanks for the great gem!