### PR TITLE
Postgres plaintext search for blank values

### DIFF
--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -42,8 +42,14 @@ module CryptKeeper
       end
 
       def search(records, field, criteria)
-        records.where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)",
-          key, criteria)
+        if criteria.present?
+          records
+            .where.not("TRIM(BOTH FROM #{field}) = ?", "")
+            .where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)",
+                   key, criteria)
+        else
+          records.where("#{field}" => criteria)
+        end
       end
 
       private

--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -48,7 +48,7 @@ module CryptKeeper
             .where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)",
                    key, criteria)
         else
-          records.where("#{field}" => criteria)
+          records.where(field => criteria)
         end
       end
 

--- a/spec/crypt_keeper/provider/postgres_pgp_spec.rb
+++ b/spec/crypt_keeper/provider/postgres_pgp_spec.rb
@@ -64,6 +64,42 @@ describe CryptKeeper::Provider::PostgresPgp do
       match = subject.create!(storage: 'blah')
       expect(subject.search_by_plaintext(:storage, 'blah').first).to eq(match)
     end
+
+    it "successfully accesses result when the data has empty strings and nil" do
+      subject.create!(storage: nil)
+      subject.create!(storage: '')
+      subject.create!(storage: '   ')
+      match = subject.create!(storage: 'blah')
+
+      results = subject.search_by_plaintext(:storage, 'blah')
+
+      expect(results).to match_array([match])
+    end
+
+    it "finds an empty string" do
+      subject.create!(storage: nil)
+      subject.create!(storage: 'blah')
+      match = subject.create!(storage: '')
+
+      expect(subject.search_by_plaintext(:storage, '')).to match_array([match])
+    end
+
+    it "finds the empty string with the right number of spaces" do
+      subject.create!(storage: '')
+      match = subject.create!(storage: '   ')
+
+      results = subject.search_by_plaintext(:storage, '   ')
+
+      expect(results).to match_array([match])
+    end
+
+    it "finds nil results" do
+      subject.create!(storage: '')
+      subject.create!(storage: 'blah')
+      match = subject.create!(storage: nil)
+
+      expect(subject.search_by_plaintext(:storage, nil)).to match_array([match])
+    end
   end
 
   describe "Custom pgcrypto options" do


### PR DESCRIPTION
When encrypting data, if the input is blank, then the encryption process does not take place. This occurs both when serializing an individual row and when encrypting the entire table. You can see where this occurs in these locations:

* https://github.com/jmazzi/crypt_keeper/blob/4bfa80d08a6b9c473be923a44853e7570c5aa482/lib/crypt_keeper/provider/base.rb#L5
* https://github.com/jmazzi/crypt_keeper/blob/4bfa80d08a6b9c473be923a44853e7570c5aa482/lib/crypt_keeper/model.rb#L94

As a result of this, encrypted fields that receive input such as `nil`, `""`, and `" "` are not encrypted, and are stored in the database as their plaintext value.

When using the `search_by_plaintext` class [method](https://github.com/jmazzi/crypt_keeper/blob/4bfa80d08a6b9c473be923a44853e7570c5aa482/lib/crypt_keeper/model.rb#L78), the encryptor's `search` method is invoked. For Postgres PGP, that ends up [calling](https://github.com/jmazzi/crypt_keeper/blob/4bfa80d08a6b9c473be923a44853e7570c5aa482/lib/crypt_keeper/provider/postgres_pgp.rb#L45) Postgres' `pgp_sym_decrypt` function to decrypt each row, and then compares that decrypted value to the plaintext criteria searched for.

`pgp_sym_decrypt` will accept `null` and return `null`, which results in `null` decrypting without issue. This is outlined in the [documentation](https://www.postgresql.org/docs/9.1/pgcrypto.html):
> F.28.6.2. NULL Handling
> As is standard in SQL, all functions return NULL, if any of the arguments are NULL. This may create security risks on careless usage.

However, calling `pgp_sym_decrypt` on a blank string, such as `""` or `"
"` will attempt to decrypt the value with the provided key. That decryption will fail, resulting in the following:

```
PG::ExternalRoutineInvocationException: ERROR:  Wrong key or corrupt data
```

However, in this case, the data is not corrupt, nor is the key wrong. The issue is that the value was never encrypted to begin with.

This change confirms that behavior with additional test cases for the `PostgresPgp` provider, and changes the implementation of `search` so those tests pass. The change does the following:

* Checks to see if the criteria searched for is present. If it is not, do not attempt to decrypt at all. Instead, search for values that meet the criteria directly. This allows for searching of `nil`, `""`, and `"
"`, without the need for the decryption which may fail if there's data in the database that would match, and also makes sure that if `"   "` is searched for, no record that is `""` (note the difference in number of spaces) is returned.
* If criteria is present, do not include records for decryption that only contain whitespace. This trims both sides of the field being searched against, and if the result is the empty string, does not include that row for the decryption operation and comparison to the criteria. Given that we know the criteria is present, none of these rows should match that anyway, and now we can safely decrypt these values. We don't need to do anything special with `nil`, as `pgp_sym_decrypt` will return `null` already, as previously pointed out.