### PR TITLE
Test ruby 2.5 and 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.5.3
+  - 2.6.0
 
 gemfile:
   - gemfiles/activerecord_4_2.gemfile


### PR DESCRIPTION
This expands the test matrix for Travis CI to also test against the
latest point release of ruby 2.5 (2.5.3) and 2.6 (2.6.0) as of this commit.