### PR TITLE
Fix for PG::SyntaxError: ERROR:  syntax error at or near ")"

### DIFF
--- a/lib/crypt_keeper/provider/postgres_pgp.rb
+++ b/lib/crypt_keeper/provider/postgres_pgp.rb
@@ -44,7 +44,7 @@ module CryptKeeper
       def search(records, field, criteria)
         if criteria.present?
           records
-            .where.not("TRIM(BOTH FROM #{field}) = ?", "")
+            .where.not("TRIM(BOTH FROM \"#{field}\") = ?", "")
             .where("(pgp_sym_decrypt(cast(\"#{field}\" AS bytea), ?) = ?)",
                    key, criteria)
         else


### PR DESCRIPTION
This is somewhat related to the fix I had done in https://github.com/jmazzi/crypt_keeper/pull/137 .

It was triggered by running something like `Model.search_by_plaintext(:full, '123').count`

```
Caused by PG::SyntaxError: ERROR:  syntax error at or near ")"
LINE 1: AND NOT (TRIM(BOTH FROM full) = '')
```


Some details were removed from the above error. This change appears to fix the issue.