### PR TITLE
Allow all version of the 7.0.x versions of Rails

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -36,7 +36,7 @@ appraise "activerecord_6_1" do
 end
 
 appraise "activerecord_7_0" do
-  gem "activerecord",  "~> 7.0"
-  gem "activesupport", "~> 7.0"
+  gem "activerecord",  "~> 7.0.0"
+  gem "activesupport", "~> 7.0.0"
   gem "pg", "~> 1.1"
 end

--- a/crypt_keeper.gemspec
+++ b/crypt_keeper.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.post_install_message = "WARNING: CryptKeeper 2.0 contains breaking changes and may require you to reencrypt your data! Please view the README at https://github.com/jmazzi/crypt_keeper for more information."
 
-  gem.add_runtime_dependency 'activerecord',  '>= 4.2', '<= 7'
-  gem.add_runtime_dependency 'activesupport', '>= 4.2', '<= 7'
+  gem.add_runtime_dependency 'activerecord',  '>= 4.2', '~> 7.0.0'
+  gem.add_runtime_dependency 'activesupport', '>= 4.2', '~> 7.0.0'
 
   gem.add_development_dependency 'rspec',       '~> 3.5.0'
   gem.add_development_dependency 'guard',       '~> 2.6.1'

--- a/gemfiles/activerecord_7_0.gemfile
+++ b/gemfiles/activerecord_7_0.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0"
-gem "activesupport", "~> 7.0"
+gem "activerecord", "~> 7.0.0"
+gem "activesupport", "~> 7.0.0"
 gem "pg", "~> 1.1"
 
 gemspec :path => "../"


### PR DESCRIPTION
In MR #193 it does not allow versions `7.0.2` of Rails. Also use consistent version requirements as in Appraisals and gemspec.