### PR TITLE
Update gem_spec

### DIFF
--- a/crypt_keeper.gemspec
+++ b/crypt_keeper.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.post_install_message = "WARNING: CryptKeeper 2.0 contains breaking changes and may require you to reencrypt your data! Please view the README at https://github.com/jmazzi/crypt_keeper for more information."
 
-  gem.add_runtime_dependency 'activerecord',  '>= 4.2', '~> 7.0.0'
-  gem.add_runtime_dependency 'activesupport', '>= 4.2', '~> 7.0.0'
+  gem.add_runtime_dependency 'activerecord',  '>= 4.2', '< 7.3'
+  gem.add_runtime_dependency 'activesupport', '>= 4.2', '< 7.3'
 
   gem.add_development_dependency 'rspec',       '~> 3.5.0'
   gem.add_development_dependency 'guard',       '~> 2.6.1'


### PR DESCRIPTION
In order for us to upgrade the ATS to Rails 7.2, we need to loosen the dependency chain that the crypt_keeper gem has. Upgrading the ATS to Rails 7.X is currently blocked by:

Because crypt_keeper >= 2.3.0 depends on activesupport >= 4.2, <= 7
  and rails >= 7.0.10, < 7.1.0.beta1 depends on activesupport = 7.0.10,
  crypt_keeper >= 2.3.0 is incompatible with rails >= 7.0.10, < 7.1.0.beta1.
So, because Gemfile depends on rails ~> 7.0.10
  and Gemfile depends on crypt_keeper ~> 2.3.0,
  version solving has failed.

So the plan is:

1) Fork the gem
2) Loosen the requirements
3) Point our Rails 7.X ATS gemfile to the fork
4) Upgrade the ATS up to 7.2 and replace all usage of the CryptKeeper gem with the Rails 7.X encryption engine.